### PR TITLE
#45 Computed columns to application table

### DIFF
--- a/database/buildSchema/19_b_application_stage_status.sql
+++ b/database/buildSchema/19_b_application_stage_status.sql
@@ -1,10 +1,10 @@
 -- Create VIEW which collects application, stage and status information together
 CREATE VIEW public.application_stage_status AS
 	(SELECT app.id,
-			name,
-			ts.number AS stage_number,
-			ts.title AS stage,
-			status
+		name,
+		ts.number AS stage_number,
+		ts.title AS stage,
+		status
 	FROM application app
 	JOIN application_stage_history stage ON app.id = stage.application_id
 	JOIN template_stage ts ON stage.stage_id = ts.id

--- a/database/buildSchema/19_b_application_stage_status.sql
+++ b/database/buildSchema/19_b_application_stage_status.sql
@@ -1,0 +1,41 @@
+-- Create VIEW which collects application, stage and status information together
+
+CREATE VIEW public.application_stage_status AS
+				(SELECT app.id,
+						name,
+						ts.number AS stage_number,
+						ts.title AS stage,
+						status
+					FROM application app
+					JOIN application_stage_history stage ON app.id = stage.application_id
+					JOIN template_stage ts ON stage.stage_id = ts.id
+					JOIN application_status_history status ON stage.id = status.application_stage_history_id
+					WHERE stage.is_current = TRUE
+									AND status.is_current = TRUE );
+
+-- Function to expose stage_number field on application table in GraphQL
+
+CREATE FUNCTION public.application_stage_number(app public.application) RETURNS INT AS $$
+	SELECT stage_number FROM
+		( SELECT id, stage_number FROM
+			public.application_stage_status ) AS app_stage_num
+	WHERE app_stage_num.id = app.id
+$$ LANGUAGE sql STABLE;
+
+-- Function to expose stage name field on application table in GraphQL
+
+CREATE FUNCTION public.application_stage(app public.application) RETURNS VARCHAR AS $$
+	SELECT stage FROM
+		( SELECT id, stage FROM
+			public.application_stage_status	) AS app_stage
+	WHERE app_stage.id = app.id
+$$ LANGUAGE sql STABLE;
+
+-- Function to expose status field on application table in GraphQL
+
+CREATE FUNCTION public.application_status(a public.application) RETURNS application_status AS $$
+	SELECT status FROM
+		( SELECT id, status FROM
+			public.application_stage_status ) AS app_status
+	WHERE app_status.id = a.id
+$$ LANGUAGE sql STABLE;

--- a/database/buildSchema/19_b_application_stage_status.sql
+++ b/database/buildSchema/19_b_application_stage_status.sql
@@ -1,39 +1,41 @@
 -- Create VIEW which collects application, stage and status information together
-
 CREATE VIEW public.application_stage_status AS
-				(SELECT app.id,
-						name,
-						ts.number AS stage_number,
-						ts.title AS stage,
-						status
-					FROM application app
-					JOIN application_stage_history stage ON app.id = stage.application_id
-					JOIN template_stage ts ON stage.stage_id = ts.id
-					JOIN application_status_history status ON stage.id = status.application_stage_history_id
-					WHERE stage.is_current = TRUE
-									AND status.is_current = TRUE );
+	(SELECT app.id,
+			name,
+			ts.number AS stage_number,
+			ts.title AS stage,
+			status
+	FROM application app
+	JOIN application_stage_history stage ON app.id = stage.application_id
+	JOIN template_stage ts ON stage.stage_id = ts.id
+	JOIN application_status_history status ON stage.id = status.application_stage_history_id
+	WHERE stage.is_current = TRUE
+	AND status.is_current = TRUE );
+
 
 -- Function to expose stage_number field on application table in GraphQL
-
-CREATE FUNCTION public.application_stage_number(app public.application) RETURNS INT AS $$
+CREATE FUNCTION public.application_stage_number(app public.application)
+RETURNS INT AS $$
 	SELECT stage_number FROM
 		( SELECT id, stage_number FROM
 			public.application_stage_status ) AS app_stage_num
 	WHERE app_stage_num.id = app.id
 $$ LANGUAGE sql STABLE;
 
--- Function to expose stage name field on application table in GraphQL
 
-CREATE FUNCTION public.application_stage(app public.application) RETURNS VARCHAR AS $$
+-- Function to expose stage name field on application table in GraphQL
+CREATE FUNCTION public.application_stage(app public.application)
+RETURNS VARCHAR AS $$
 	SELECT stage FROM
 		( SELECT id, stage FROM
 			public.application_stage_status	) AS app_stage
 	WHERE app_stage.id = app.id
 $$ LANGUAGE sql STABLE;
 
--- Function to expose status field on application table in GraphQL
 
-CREATE FUNCTION public.application_status(a public.application) RETURNS application_status AS $$
+-- Function to expose status field on application table in GraphQL
+CREATE FUNCTION public.application_status(a public.application)
+RETURNS application_status AS $$
 	SELECT status FROM
 		( SELECT id, status FROM
 			public.application_stage_status ) AS app_status

--- a/database/buildSchema/19_b_application_stage_status.sql
+++ b/database/buildSchema/19_b_application_stage_status.sql
@@ -2,12 +2,12 @@
 CREATE VIEW public.application_stage_status AS
 	(SELECT app.id,
 		name,
-		ts.number AS stage_number,
-		ts.title AS stage,
+		template_stage.number AS stage_number,
+		template_stage.title AS stage,
 		status
 	FROM application app
 	JOIN application_stage_history stage ON app.id = stage.application_id
-	JOIN template_stage ts ON stage.stage_id = ts.id
+	JOIN template_stage ON stage.stage_id = template_stage.id
 	JOIN application_status_history status ON stage.id = status.application_stage_history_id
 	WHERE stage.is_current = TRUE
 	AND status.is_current = TRUE );


### PR DESCRIPTION
Implements #45 (as discussed in [this comment](https://github.com/openmsupply/application-manager-server/issues/36#issuecomment-700384134) in #36).

Note: have added new .sql file, but numbered it `19_b)_...` -- I think it's best not to re-number other files while we're actively working on them on multiple branches. Let's do all re-numbering as a single issue once schema is fairly stable.

To test: re-run `yarn database_init` script. In PostGraphile GUI, the `stage`, `stage_number` and `status` fields should be available on the `applications` table.

The query:
```
query GetApps {
  applications {
    nodes {
      stageNumber
      stage
      name
      status
    }
  }
}
```
should yield:
```
{
  "data": {
    "applications": {
      "nodes": [
        {
          "stageNumber": 1,
          "stage": "Screening",
          "name": "User Registration: Nicole Madruga",
          "status": "COMPLETED"
        },
        {
          "stageNumber": 1,
          "stage": "Screening",
          "name": "User Registration: Carl Smith",
          "status": "COMPLETED"
        },
        {
          "stageNumber": 2,
          "stage": "Assessment",
          "name": "Company Registration: Company C",
          "status": "SUBMITTED"
        }
      ]
    }
  }
}
```