### PR TITLE
#56 Endpoint to check for unique values

### DIFF
--- a/database/insertData.js
+++ b/database/insertData.js
@@ -462,6 +462,22 @@ const queries = [
       }
     }
   }`,
+  //   Add one organisation
+  `mutation {
+    createOrganisation(
+      input: {
+        organisation: {
+          address: "123 Nowhere St\\nAuckland"
+          licenceNumber: "XYZ1234"
+          name: "Drugs-R-Us"
+        }
+      }
+    ) {
+      organisation {
+        name
+      }
+    }
+  }`,
   //   User registration application 1
   `mutation {
     createApplication(

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -241,8 +241,7 @@ class PostgresDB {
       const result = await this.query({ text, values: [value] })
       return !Boolean(Number(result.rows[0].count))
     } catch (err) {
-      console.log(err.stack)
-      return false
+      throw err
     }
   }
 }

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -234,6 +234,17 @@ class PostgresDB {
       return false
     }
   }
+
+  public isUnique = async (table: string, field: string, value: string): Promise<boolean> => {
+    const text = `SELECT COUNT(*) FROM "${table}" WHERE ${field} = $1`
+    try {
+      const result = await this.query({ text, values: [value] })
+      return !Boolean(Number(result.rows[0].count))
+    } catch (err) {
+      console.log(err.stack)
+      return false
+    }
+  }
 }
 
 const postgressDBInstance = PostgresDB.Instance

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -236,7 +236,7 @@ class PostgresDB {
   }
 
   public isUnique = async (table: string, field: string, value: string): Promise<boolean> => {
-    const text = `SELECT COUNT(*) FROM "${table}" WHERE ${field} = $1`
+    const text = `SELECT COUNT(*) FROM "${table}" WHERE LOWER(${field}) = LOWER($1)`
     try {
       const result = await this.query({ text, values: [value] })
       return !Boolean(Number(result.rows[0].count))

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,92 @@
+// Test suite for Fastify server endpoints
+const fetch = require('node-fetch')
+
+// Config
+const baseURL = 'http://localhost:8080/'
+
+const getRequest = async (url: string) => {
+  const response = await fetch(url)
+  const data = response.json()
+  return data
+}
+
+// check-unique endpoint
+test('Check unique: username is not unique', () => {
+  return getRequest(`${baseURL}check-unique?&type=username&value=nmadruga`).then((result: any) => {
+    expect(result).toBe(false)
+  })
+})
+
+test('Check unique: username is unique', () => {
+  return getRequest(`${baseURL}check-unique?&type=username&value=nicole_m`).then((result: any) => {
+    expect(result).toBe(true)
+  })
+})
+
+test('Check unique: email is not unique', () => {
+  return getRequest(`${baseURL}check-unique?&type=email&value=andrei@sussol.net`).then(
+    (result: any) => {
+      expect(result).toBe(false)
+    }
+  )
+})
+
+test('Check unique: email is unique', () => {
+  return getRequest(`${baseURL}check-unique?&type=email&value=tony@sussol.net`).then(
+    (result: any) => {
+      expect(result).toBe(true)
+    }
+  )
+})
+
+test('Check unique: organisation is not unique', () => {
+  return getRequest(`${baseURL}check-unique?&type=organisation&value=Drugs-R-Us`).then(
+    (result: any) => {
+      expect(result).toBe(false)
+    }
+  )
+})
+
+test('Check unique: organisation is unique', () => {
+  return getRequest(`${baseURL}check-unique?&type=organisation&value=A New Drug Company`).then(
+    (result: any) => {
+      expect(result).toBe(true)
+    }
+  )
+})
+
+test('Check unique: Case-insensitivity - not unique, even though case differs from DB', () => {
+  return getRequest(`${baseURL}check-unique?&type=email&value=Nicole@SuSSol.net`).then(
+    (result: any) => {
+      expect(result).toBe(false)
+    }
+  )
+})
+
+test('Check unique: Returns false when query is invalid (misnamed type field)', () => {
+  return getRequest(`${baseURL}check-unique?&typO=email&value=carl@sussol.net`).then(
+    (result: any) => {
+      expect(result).toBe(false)
+    }
+  )
+})
+
+test('Check unique: Returns false when query is invalid (type is invalid)', () => {
+  return getRequest(`${baseURL}check-unique?&type=firstName&value=carl@sussol.net`).then(
+    (result: any) => {
+      expect(result).toBe(false)
+    }
+  )
+})
+
+test('Check unique: Returns false when value is blank', () => {
+  return getRequest(`${baseURL}check-unique?&type=username&value=`).then((result: any) => {
+    expect(result).toBe(false)
+  })
+})
+
+test('Check unique: Returns false when value field not provided', () => {
+  return getRequest(`${baseURL}check-unique?&type=username`).then((result: any) => {
+    expect(result).toBe(false)
+  })
+})

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -13,20 +13,20 @@ const getRequest = async (url: string) => {
 // check-unique endpoint
 test('Check unique: username is not unique', () => {
   return getRequest(`${baseURL}check-unique?&type=username&value=nmadruga`).then((result: any) => {
-    expect(result).toBe(false)
+    expect(result).toEqual({ unique: false, message: '' })
   })
 })
 
 test('Check unique: username is unique', () => {
   return getRequest(`${baseURL}check-unique?&type=username&value=nicole_m`).then((result: any) => {
-    expect(result).toBe(true)
+    expect(result).toEqual({ unique: true, message: '' })
   })
 })
 
 test('Check unique: email is not unique', () => {
   return getRequest(`${baseURL}check-unique?&type=email&value=andrei@sussol.net`).then(
     (result: any) => {
-      expect(result).toBe(false)
+      expect(result).toEqual({ unique: false, message: '' })
     }
   )
 })
@@ -34,7 +34,7 @@ test('Check unique: email is not unique', () => {
 test('Check unique: email is unique', () => {
   return getRequest(`${baseURL}check-unique?&type=email&value=tony@sussol.net`).then(
     (result: any) => {
-      expect(result).toBe(true)
+      expect(result).toEqual({ unique: true, message: '' })
     }
   )
 })
@@ -42,7 +42,7 @@ test('Check unique: email is unique', () => {
 test('Check unique: organisation is not unique', () => {
   return getRequest(`${baseURL}check-unique?&type=organisation&value=Drugs-R-Us`).then(
     (result: any) => {
-      expect(result).toBe(false)
+      expect(result).toEqual({ unique: false, message: '' })
     }
   )
 })
@@ -50,7 +50,7 @@ test('Check unique: organisation is not unique', () => {
 test('Check unique: organisation is unique', () => {
   return getRequest(`${baseURL}check-unique?&type=organisation&value=A New Drug Company`).then(
     (result: any) => {
-      expect(result).toBe(true)
+      expect(result).toEqual({ unique: true, message: '' })
     }
   )
 })
@@ -58,7 +58,7 @@ test('Check unique: organisation is unique', () => {
 test('Check unique: Case-insensitivity - not unique, even though case differs from DB', () => {
   return getRequest(`${baseURL}check-unique?&type=email&value=Nicole@SuSSol.net`).then(
     (result: any) => {
-      expect(result).toBe(false)
+      expect(result).toEqual({ unique: false, message: '' })
     }
   )
 })
@@ -66,7 +66,10 @@ test('Check unique: Case-insensitivity - not unique, even though case differs fr
 test('Check unique: Returns false when query is invalid (misnamed type field)', () => {
   return getRequest(`${baseURL}check-unique?&typO=email&value=carl@sussol.net`).then(
     (result: any) => {
-      expect(result).toBe(false)
+      expect(result).toEqual({
+        unique: false,
+        message: 'Type missing or invalid',
+      })
     }
   )
 })
@@ -74,19 +77,30 @@ test('Check unique: Returns false when query is invalid (misnamed type field)', 
 test('Check unique: Returns false when query is invalid (type is invalid)', () => {
   return getRequest(`${baseURL}check-unique?&type=firstName&value=carl@sussol.net`).then(
     (result: any) => {
-      expect(result).toBe(false)
+      expect(result).toEqual({
+        unique: false,
+        message: 'Type missing or invalid',
+      })
     }
   )
 })
 
 test('Check unique: Returns false when value is blank', () => {
   return getRequest(`${baseURL}check-unique?&type=username&value=`).then((result: any) => {
-    expect(result).toBe(false)
+    expect(result).toEqual({
+      unique: false,
+      message: 'Value not provided',
+    })
   })
 })
 
 test('Check unique: Returns false when value field not provided', () => {
   return getRequest(`${baseURL}check-unique?&type=username`).then((result: any) => {
-    expect(result).toBe(false)
+    expect(result).toEqual({
+      unique: false,
+      message: 'Value not provided',
+    })
   })
 })
+
+// To-do: write tests for database errors

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,8 +49,7 @@ const startServer = async () => {
 
   // Unique name/email/organisation check
   server.get('/check-unique', async (request: any, reply) => {
-    const type = request.query.type
-    const value = request.query.value
+    const { type, value } = request.query
     if (value === '' || value === undefined) return false
     let table, field
     switch (type) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import {
   filesFolderName,
 } from './components/fileHandler'
 import { getAppRootDir } from './components/utilityFunctions'
+import PostgresDB from './components/postgresConnect'
 
 // Bare-bones Fastify server
 
@@ -44,6 +45,31 @@ const startServer = async () => {
   server.get('/', async (request, reply) => {
     console.log('Request made')
     return 'This is the response\n'
+  })
+
+  // Unique name/email/company check
+  server.get('/check-unique', async (request: any, reply) => {
+    const type = request.query.type
+    const value = request.query.value
+    let table, field
+    switch (type) {
+      case 'username':
+        table = 'user'
+        field = 'username'
+        break
+      case 'email':
+        table = 'user'
+        field = 'email'
+        break
+      case 'organisation':
+        table = 'organisation'
+        field = 'name'
+        break
+      default:
+        return null
+    }
+    const isUnique = await PostgresDB.isUnique(table, field, value)
+    return isUnique
   })
 
   server.listen(8080, (err, address) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,13 @@ const startServer = async () => {
   // Unique name/email/organisation check
   server.get('/check-unique', async (request: any, reply) => {
     const { type, value } = request.query
-    if (value === '' || value === undefined) return false
+    if (value === '' || value === undefined) {
+      reply.send({
+        unique: false,
+        message: 'Value not provided',
+      })
+      return
+    }
     let table, field
     switch (type) {
       case 'username':
@@ -66,10 +72,21 @@ const startServer = async () => {
         field = 'name'
         break
       default:
-        return false
+        reply.send({
+          unique: false,
+          message: 'Type missing or invalid',
+        })
+        return
     }
-    const isUnique = await PostgresDB.isUnique(table, field, value)
-    return isUnique
+    try {
+      const isUnique = await PostgresDB.isUnique(table, field, value)
+      reply.send({
+        unique: isUnique,
+        message: '',
+      })
+    } catch (err) {
+      reply.send({ unique: false, message: err.message })
+    }
   })
 
   server.listen(8080, (err, address) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,7 @@ const startServer = async () => {
   server.get('/check-unique', async (request: any, reply) => {
     const type = request.query.type
     const value = request.query.value
+    if (value === '' || value === undefined) return false
     let table, field
     switch (type) {
       case 'username':
@@ -66,7 +67,7 @@ const startServer = async () => {
         field = 'name'
         break
       default:
-        return null
+        return false
     }
     const isUnique = await PostgresDB.isUnique(table, field, value)
     return isUnique

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ const startServer = async () => {
     return 'This is the response\n'
   })
 
-  // Unique name/email/company check
+  // Unique name/email/organisation check
   server.get('/check-unique', async (request: any, reply) => {
     const type = request.query.type
     const value = request.query.value


### PR DESCRIPTION
Fixes #56

Endpoint is provided at `/check-unique`.
Query parameters are:
- `type`: available options: `username`, `email`, `organisation`
- `value`: the value being checked for uniqueness

Example request URL: `/check-unique/type=email&value=carl@sussol.net`

Check is case-insensitive, so `carlsmith` will return Not Unique if `CarlSmith` is in the database.

Returns a boolean.

I created a unit test suite. Run: `yarn test src/server.test.ts`

And please try out your own queries with Postman.

Also: added one organisation to database in `insertData.js`