### PR TITLE
Fix mistake with record_id being labelled template_id in trigger payload

### DIFF
--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -187,7 +187,7 @@ class PostgresDB {
     WHERE template_id = (SELECT template_id FROM ${tableName} WHERE id = $1) AND trigger = $2`
 
     try {
-      const result = await this.query({ text, values: [payload.template_id, payload.trigger] })
+      const result = await this.query({ text, values: [payload.record_id, payload.trigger] })
       return result.rows as ActionInTemplate[]
     } catch (err) {
       throw err

--- a/src/components/triggersAndActions.ts
+++ b/src/components/triggersAndActions.ts
@@ -80,7 +80,7 @@ export const loadScheduledActions = async function (
 export async function processTrigger(payload: TriggerPayload) {
   // Get Actions from matching Template
   const result = await PostgresDB.getActionPluginsByTemplate(payload.table, {
-    template_id: payload.record_id,
+    record_id: payload.record_id,
     trigger: payload.trigger,
   })
   // Filter out Actions that don't match the current condition

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface ActionInTemplate {
 }
 
 export interface ActionInTemplateGetPayload {
-  template_id: number
+  record_id: number
   trigger: TriggerStatus
 }
 


### PR DESCRIPTION
Very quick fix, but important -- noticed when I was talking about Actions with @andreievg .

The `record_id` field in the trigger payload had been mis-named as `template_id`. It's not template id, it's the id of record from whatever table it came from -- could be application, review, etc.