### PR TITLE
#74 expression evaluator input handling

### DIFF
--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -487,7 +487,7 @@ test('Test visibility condition -- Answer to Q1 is Drug Registration and user be
 //   });
 // });
 
-// Invalid input expressions
+// Non-standard input expressions
 
 test('Input is a number', () => {
   return evaluateExpression(10).then((result: any) => {
@@ -501,13 +501,10 @@ test('Input is an array', () => {
   })
 })
 
-test('Input is malformed JSON string', () => {
-  expect(
-    async () =>
-      await evaluateExpression(
-        '{"operator":"=", "children":[{"value":6},{"operator":"+", "children":[{"value":6},{"value":6}]}]}}'
-      )
-  ).rejects.toThrow('Invalid JSON String')
+test('Input is an string', () => {
+  return evaluateExpression('Friday drinks?').then((result: any) => {
+    expect(result).toEqual('Friday drinks?')
+  })
 })
 
 afterAll(() => {

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -13,7 +13,8 @@ export default async function evaluateExpression(
       try {
         query = JSON.parse(inputQuery)
       } catch {
-        throw new Error('Invalid JSON String')
+        return inputQuery
+        // throw new Error('Invalid JSON String')
       }
     } else return inputQuery
   } else query = inputQuery

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -14,7 +14,6 @@ export default async function evaluateExpression(
         query = JSON.parse(inputQuery)
       } catch {
         return inputQuery
-        // throw new Error('Invalid JSON String')
       }
     } else return inputQuery
   } else query = inputQuery


### PR DESCRIPTION
Very small change -- just return all literal strings as-is.

Previously, it was assuming a string was an attempted JSON string, so would throw an error if Invalid JSON. Now it just returns the string. Only down-side is that genuinely invalid JSON strings will not throw an error but return the string. But a worthwhile trade-off to be able to simplify queries like this, for example:

```
{
  operator: "CONCAT",
  children: [ "Carl", " ", "Smith" ]
}
```