### PR TITLE
#71F Validation improvements

### DIFF
--- a/database/buildSchema/14_template_element.sql
+++ b/database/buildSchema/14_template_element.sql
@@ -13,7 +13,7 @@ CREATE TABLE public.template_element (
     element_type_plugin_code varchar,
     is_required jsonb DEFAULT '{"value":true}'::jsonb,
     is_editable jsonb DEFAULT '{"value":true}'::jsonb,
-    parameters jsonb,
-    validation jsonb DEFAULT '{"value":true}'::jsonb,
-    validation_message varchar
+    parameters jsonb
+--     validation jsonb DEFAULT '{"value":true}'::jsonb,
+--     validation_message varchar
 );

--- a/database/buildSchema/14_template_element.sql
+++ b/database/buildSchema/14_template_element.sql
@@ -14,6 +14,4 @@ CREATE TABLE public.template_element (
     is_required jsonb DEFAULT '{"value":true}'::jsonb,
     is_editable jsonb DEFAULT '{"value":true}'::jsonb,
     parameters jsonb
---     validation jsonb DEFAULT '{"value":true}'::jsonb,
---     validation_message varchar
 );

--- a/database/buildSchema/20_application_response.sql
+++ b/database/buildSchema/20_application_response.sql
@@ -5,5 +5,6 @@ CREATE TABLE public.application_response (
     template_element_id integer references public.template_element(id),
     application_id integer references public.application(id),
     value jsonb,
+    is_valid boolean,
     time_created timestamp with time zone
 );

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -47,7 +47,35 @@ const queries = [
                       title: "Last Name"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { label: "Last Name" }
+                      parameters: {
+                        label: "Last Name"
+                        validation: {
+                          operator: "AND"
+                          children: [
+                            {
+                              operator: "!="
+                              children: [
+                                {
+                                  operator: "objectProperties"
+                                  children: [{ value: { property: "Q1" } }]
+                                }
+                                { value: null }
+                              ]
+                            }
+                            {
+                              operator: "!="
+                              children: [
+                                {
+                                  operator: "objectProperties"
+                                  children: [{ value: { property: "Q1" } }]
+                                }
+                                { value: "" }
+                              ]
+                            }
+                          ]
+                        }
+                        validationMessage: "You need a first name."
+                      }
                     }
                     {
                       code: "Q3"
@@ -55,6 +83,16 @@ const queries = [
                       title: "Username"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      visibilityCondition: {
+                        operator: "!="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "Q1" } }]
+                          }
+                          { value: "" }
+                        ]
+                      }
                       parameters: {
                         label: "Select a username"
                         validation: {
@@ -62,9 +100,9 @@ const queries = [
                           children: [
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q3" } }]
+                              children: [{ value: { property: "thisResponse" } }]
                             }
-                            "^[A-z0-9]{3,}$"
+                            { value: "^[A-z0-9]{3,}$" }
                           ]
                         }
                         validationMessage: "Username must be at least 3 characters long and not contain spaces"
@@ -83,9 +121,11 @@ const queries = [
                           children: [
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q4" } }]
+                              children: [{ value: { property: "thisResponse" } }]
                             }
-                            "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
+                            {
+                              value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
+                            }
                           ]
                         }
                         validationMessage: "Not a valid email address"
@@ -100,19 +140,19 @@ const queries = [
                       parameters: {
                         label: "Email"
                         maskedInput: true
+                        placeholder: "Password must be at least 8 chars long"
                         validation: {
                           operator: "REGEX"
                           children: [
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q5" } }]
+                              children: [{ value: { property: "thisResponse" } }]
                             }
-                            "^[\\\\S]{8,}$"
+                            { value: "^[\\\\S]{8,}$" }
                           ]
                         }
                         validationMessage: "Password must be at least 8 characters"
-                      }
-  
+                      } 
                       # Validation:Currently just checks 8 chars, needs more complexity
                     }
                     {

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -96,16 +96,21 @@ const queries = [
                       parameters: {
                         label: "Select a username"
                         validation: {
-                          operator: "REGEX"
+                          operator: "API"
                           children: [
+                            { value: "http://localhost:8080/check-unique" }
+                            { value: ["type", "value"] }
+                            { value: "username" }
                             {
                               operator: "objectProperties"
                               children: [{ value: { property: "thisResponse" } }]
                             }
-                            { value: "^[A-z0-9]{3,}$" }
+                            {
+                              value: "unique"
+                            }
                           ]
                         }
-                        validationMessage: "Username must be at least 3 characters long and not contain spaces"
+                        validationMessage: "Username must be unique"
                       }
                     }
                     {

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -55,9 +55,20 @@ const queries = [
                       title: "Username"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { label: "Select a username" }
-                      validation: { value: true } #Need to write this query
-                      # Validation: Must be unique, Alphanumeric chars only, no spaces
+                      parameters: {
+                        label: "Select a username"
+                        validation: {
+                          operator: "REGEX"
+                          children: [
+                            {
+                              operator: "objectProperties"
+                              children: [{ value: { property: "Q3" } }]
+                            }
+                            "^[A-z0-9]{3,}$"
+                          ]
+                        }
+                        validationMessage: "Username must be at least 3 characters long and not contain spaces"
+                      }
                     }
                     {
                       code: "Q4"
@@ -65,9 +76,20 @@ const queries = [
                       title: "Email"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { label: "Email" }
-                      validation: { value: true } #Need to write this query
-                      # Validation: Email REGEX check, must be unique in system
+                      parameters: {
+                        label: "Email"
+                        validation: {
+                          operator: "REGEX"
+                          children: [
+                            {
+                              operator: "objectProperties"
+                              children: [{ value: { property: "Q4" } }]
+                            }
+                            "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
+                          ]
+                        }
+                        validationMessage: "Not a valid email address"
+                      }
                     }
                     {
                       code: "Q5"
@@ -75,9 +97,23 @@ const queries = [
                       title: "Password"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { label: "Email", maskedInput: true }
-                      validation: { value: true } #Need to write this query
-                      # Validation: At least 8 chars, must contain at least one letter and one number (REGEX)
+                      parameters: {
+                        label: "Email"
+                        maskedInput: true
+                        validation: {
+                          operator: "REGEX"
+                          children: [
+                            {
+                              operator: "objectProperties"
+                              children: [{ value: { property: "Q5" } }]
+                            }
+                            "^[\\\\S]{8,}$"
+                          ]
+                        }
+                        validationMessage: "Password must be at least 8 characters"
+                      }
+  
+                      # Validation:Currently just checks 8 chars, needs more complexity
                     }
                     {
                       code: "PB1"
@@ -337,7 +373,6 @@ const queries = [
                       elementTypePluginCode: "shortText"
                       category: QUESTION
                       parameters: { label: "Unique Name for Company" }
-                      validation: { value: true }
                       # Validation TO-DO: must be unique in system
                     }
                     {

--- a/documentation/Elements-Questions.md
+++ b/documentation/Elements-Questions.md
@@ -1,1 +1,3 @@
 # Elements/Questions of Applications templates
+
+See [front-end docs](https://github.com/openmsupply/application-manager-web-app/wiki/Element-Type-Specs) for Form element specifications.

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1051,6 +1051,7 @@ export type ApplicationResponse = Node & {
   templateElementId?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   /** Reads a single `TemplateElement` that is related to this `ApplicationResponse`. */
   templateElement?: Maybe<TemplateElement>;
@@ -1111,6 +1112,7 @@ export type ApplicationResponseApplicationIdFkeyApplicationResponseCreateInput =
   id?: Maybe<Scalars['Int']>;
   templateElementId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -1185,6 +1187,8 @@ export type ApplicationResponseCondition = {
   applicationId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `value` field. */
   value?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `isValid` field. */
+  isValid?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `timeCreated` field. */
   timeCreated?: Maybe<Scalars['Datetime']>;
 };
@@ -1199,6 +1203,8 @@ export type ApplicationResponseFilter = {
   applicationId?: Maybe<IntFilter>;
   /** Filter by the object’s `value` field. */
   value?: Maybe<JsonFilter>;
+  /** Filter by the object’s `isValid` field. */
+  isValid?: Maybe<BooleanFilter>;
   /** Filter by the object’s `timeCreated` field. */
   timeCreated?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `reviewResponses` relation. */
@@ -1231,6 +1237,7 @@ export type ApplicationResponseInput = {
   templateElementId?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -1316,6 +1323,7 @@ export type ApplicationResponsePatch = {
   templateElementId?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -1356,6 +1364,8 @@ export enum ApplicationResponsesOrderBy {
   ApplicationIdDesc = 'APPLICATION_ID_DESC',
   ValueAsc = 'VALUE_ASC',
   ValueDesc = 'VALUE_DESC',
+  IsValidAsc = 'IS_VALID_ASC',
+  IsValidDesc = 'IS_VALID_DESC',
   TimeCreatedAsc = 'TIME_CREATED_ASC',
   TimeCreatedDesc = 'TIME_CREATED_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -1367,6 +1377,7 @@ export type ApplicationResponseTemplateElementIdFkeyApplicationResponseCreateInp
   id?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -5671,6 +5682,7 @@ export type FileApplicationResponseIdFkeyApplicationResponseCreateInput = {
   templateElementId?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -10146,6 +10158,7 @@ export type ReviewResponseApplicationResponseIdFkeyApplicationResponseCreateInpu
   templateElementId?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -14644,6 +14657,7 @@ export type UpdateApplicationResponseOnApplicationResponseForApplicationResponse
   id?: Maybe<Scalars['Int']>;
   templateElementId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -14656,6 +14670,7 @@ export type UpdateApplicationResponseOnApplicationResponseForApplicationResponse
   id?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -14669,6 +14684,7 @@ export type UpdateApplicationResponseOnFileForFileApplicationResponseIdFkeyPatch
   templateElementId?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -14682,6 +14698,7 @@ export type UpdateApplicationResponseOnReviewResponseForReviewResponseApplicatio
   templateElementId?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
+  isValid?: Maybe<Scalars['Boolean']>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
@@ -19965,6 +19982,7 @@ export type ApplicationResponseResolvers<ContextType = any, ParentType extends R
   templateElementId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   applicationId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   value?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  isValid?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   timeCreated?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
   templateElement?: Resolver<Maybe<ResolversTypes['TemplateElement']>, ParentType, ContextType>;
   application?: Resolver<Maybe<ResolversTypes['Application']>, ParentType, ContextType>;

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1425,8 +1425,6 @@ export type ApplicationResponseTemplateElementIdFkeyTemplateElementCreateInput =
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   parameters?: Maybe<Scalars['JSON']>;
-  validation?: Maybe<Scalars['JSON']>;
-  validationMessage?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
 };
@@ -12369,8 +12367,6 @@ export type TemplateElement = Node & {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   parameters?: Maybe<Scalars['JSON']>;
-  validation?: Maybe<Scalars['JSON']>;
-  validationMessage?: Maybe<Scalars['String']>;
   /** Reads a single `TemplateSection` that is related to this `TemplateElement`. */
   section?: Maybe<TemplateSection>;
   /** Reads and enables pagination through a set of `ApplicationResponse`. */
@@ -12447,10 +12443,6 @@ export type TemplateElementCondition = {
   isEditable?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `parameters` field. */
   parameters?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `validation` field. */
-  validation?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `validationMessage` field. */
-  validationMessage?: Maybe<Scalars['String']>;
 };
 
 /** A filter to be used against `TemplateElement` object types. All fields are combined with a logical ‘and.’ */
@@ -12477,10 +12469,6 @@ export type TemplateElementFilter = {
   isEditable?: Maybe<JsonFilter>;
   /** Filter by the object’s `parameters` field. */
   parameters?: Maybe<JsonFilter>;
-  /** Filter by the object’s `validation` field. */
-  validation?: Maybe<JsonFilter>;
-  /** Filter by the object’s `validationMessage` field. */
-  validationMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `applicationResponses` relation. */
   applicationResponses?: Maybe<TemplateElementToManyApplicationResponseFilter>;
   /** Some related `applicationResponses` exist. */
@@ -12510,8 +12498,6 @@ export type TemplateElementInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   parameters?: Maybe<Scalars['JSON']>;
-  validation?: Maybe<Scalars['JSON']>;
-  validationMessage?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
 };
@@ -12571,8 +12557,6 @@ export type TemplateElementPatch = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   parameters?: Maybe<Scalars['JSON']>;
-  validation?: Maybe<Scalars['JSON']>;
-  validationMessage?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
 };
@@ -12640,8 +12624,6 @@ export type TemplateElementSectionIdFkeyTemplateElementCreateInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   parameters?: Maybe<Scalars['JSON']>;
-  validation?: Maybe<Scalars['JSON']>;
-  validationMessage?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
 };
@@ -12693,10 +12675,6 @@ export enum TemplateElementsOrderBy {
   IsEditableDesc = 'IS_EDITABLE_DESC',
   ParametersAsc = 'PARAMETERS_ASC',
   ParametersDesc = 'PARAMETERS_DESC',
-  ValidationAsc = 'VALIDATION_ASC',
-  ValidationDesc = 'VALIDATION_DESC',
-  ValidationMessageAsc = 'VALIDATION_MESSAGE_ASC',
-  ValidationMessageDesc = 'VALIDATION_MESSAGE_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -16142,8 +16120,6 @@ export type UpdateTemplateElementOnApplicationResponseForApplicationResponseTemp
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   parameters?: Maybe<Scalars['JSON']>;
-  validation?: Maybe<Scalars['JSON']>;
-  validationMessage?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
 };
@@ -16160,8 +16136,6 @@ export type UpdateTemplateElementOnTemplateElementForTemplateElementSectionIdFke
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   parameters?: Maybe<Scalars['JSON']>;
-  validation?: Maybe<Scalars['JSON']>;
-  validationMessage?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
 };
@@ -21436,8 +21410,6 @@ export type TemplateElementResolvers<ContextType = any, ParentType extends Resol
   isRequired?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   isEditable?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   parameters?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  validation?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  validationMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   section?: Resolver<Maybe<ResolversTypes['TemplateSection']>, ParentType, ContextType>;
   applicationResponses?: Resolver<ResolversTypes['ApplicationResponsesConnection'], ParentType, ContextType, RequireFields<TemplateElementApplicationResponsesArgs, 'orderBy'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;


### PR DESCRIPTION
Changes to handle validation in front end. Please review both PRs together.

Front-end issue: https://github.com/openmsupply/application-manager-web-app/pull/125

- Added `is_valid` field to application_responses table
- Removed `validation` and `validation_message` fields and moved them to template_element parameters (as per @andreievg 's suggestion)
- Updated UserRego template queries to demonstrate validation criteria