### PR TITLE
#58 #117 Evaluator fixes

### DIFF
--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -100,6 +100,8 @@ Equality test for child nodes
 - Input: 1 or more nodes of either **string** or **number** type.
 - Output: **boolean**
 
+_Note: uses javascript "loose" equality, so `2 == "2"` and `null == undefined`._
+
 ## != (Not equal)
 
 Inequality test for child nodes
@@ -560,7 +562,7 @@ The app can be launched from either this app's folder or the root back-end folde
 
 Additional notes:
 
-- It imports the `evaluateExpression` package from the dev folder (not the published package) as this will enable live testing when actually making new changes to the evaluator.
-- `create-react-app` won't allow importing local modules outside the `src` folder. The workaround is to just re-copy the relevant files into this app's src folder on launch. This means that any changes made to the original `evaluateExpression.ts` won't show up with a hot reload -- you'll have to stop and start the app.
+- You have the option (Selector under Output header) of using the Development version or the Published (package) version of the expression-evaluator. Useful when making modifications and want to see how your changes have effected query output.
+- `create-react-app` won't allow importing local modules outside the `src` folder. The workaround is to just re-copy the relevant files into this app's src folder on launch. This means that any changes made to the original `evaluateExpression.ts` won't show up with a hot reload -- you'll have to stop and start the app. If making changes to the module, I'd recommend working on the version in the GUI project folder, then manually copying this back to the module folder when ready to commit.
 - the `node-postgres` package won't run directly from the browser, so there's a little Express server that also runs with this app that simply relays postgres queries from this app to postgres
 - API calls to local server (e.g. `http://localhost:8080/check-unique)` don't work. I don't fully understand why, but I got round it by specifying a proxy to `http://localhost:8080` in `package.json` -- you just have to put relative links as the URL. i.e. `/check-unique`

--- a/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
+++ b/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
@@ -24,8 +24,6 @@ const graphQLendpoint = config.graphQLendpoint
 
 const pgInterface = new PostgresInterface()
 
-// const evaluateExpression = evaluatorDev
-
 async function fetchNative(url, obj) {
   const result = await fetch(url, obj)
   return result

--- a/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
+++ b/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
@@ -91,7 +91,7 @@ function App() {
         setResultType('error')
       })
     localStorage.setItem('inputText', input)
-  }, [input, objectsInput, objectArray])
+  }, [input, objectsInput, objectArray, evaluatorSelection])
 
   // Try and turn object(s) input string into object array
   useEffect(() => {

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -507,6 +507,55 @@ test('Input is an string', () => {
   })
 })
 
+test('Compare two literal strings', () => {
+  return evaluateExpression({ operator: '=', children: ['monkeys', 'monkeys'] }).then(
+    (result: any) => {
+      expect(result).toEqual(true)
+    }
+  )
+})
+
+test('Compare literal string vs object value string', () => {
+  return evaluateExpression({ operator: '=', children: ['monkey', { value: 'monkey' }] }).then(
+    (result: any) => {
+      expect(result).toEqual(true)
+    }
+  )
+})
+
+test('Compare literal numbers', () => {
+  return evaluateExpression({ operator: '=', children: [234, 234] }).then((result: any) => {
+    expect(result).toEqual(true)
+  })
+})
+
+test('Compare two unequal literal strings', () => {
+  return evaluateExpression({ operator: '=', children: ['boys', 'girls'] }).then((result: any) => {
+    expect(result).toEqual(false)
+  })
+})
+
+test('Compare unequal literal string vs object value string', () => {
+  return evaluateExpression({ operator: '=', children: ['beer', { value: 'wine' }] }).then(
+    (result: any) => {
+      expect(result).toEqual(false)
+    }
+  )
+})
+
+test('Compare unequal literal numbers', () => {
+  return evaluateExpression({ operator: '=', children: [234, 7] }).then((result: any) => {
+    expect(result).toEqual(false)
+  })
+})
+
+// Null matches undefined with loose equality (==)
+test('Compare null vs undefined', () => {
+  return evaluateExpression({ operator: '=', children: [null, undefined] }).then((result: any) => {
+    expect(result).toEqual(true)
+  })
+})
+
 afterAll(() => {
   pgConnect.end()
 })

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -104,7 +104,12 @@ export default async function evaluateExpression(
         } catch {
           throw new Error('Invalid API query')
         }
-        const data = await fetchAPIdata(urlWithQuery, params.APIfetch)
+        let data
+        try {
+          data = await fetchAPIdata(urlWithQuery, params.APIfetch)
+        } catch {
+          throw new Error('Problem with API call')
+        }
         try {
           return extractAndSimplify(data, returnProperty)
         } catch {

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -8,7 +8,12 @@ export default async function evaluateExpression(
 ): Promise<string | number | boolean | BasicObject | any[]> {
   // If input is not object, try and parse it as a JSON string. If that fails, return the input without any processing.
   let query
-  if (!(inputQuery instanceof Object) || Array.isArray(inputQuery) || inputQuery === null) {
+  if (
+    !(inputQuery instanceof Object) ||
+    Array.isArray(inputQuery) ||
+    inputQuery === null ||
+    inputQuery === undefined
+  ) {
     if (typeof inputQuery === 'string') {
       try {
         query = JSON.parse(inputQuery)
@@ -20,7 +25,7 @@ export default async function evaluateExpression(
 
   // Base case
   if (!query.children) {
-    return query.value
+    return query.value !== undefined ? query.value : query
   }
 
   // Recursive case
@@ -60,10 +65,12 @@ export default async function evaluateExpression(
         }
 
       case '=':
-        return childrenResolved.every((child) => child === childrenResolved[0])
+        // eslint-disable-next-line
+        return childrenResolved.every((child) => child == childrenResolved[0])
 
       case '!=':
-        return childrenResolved[0] !== childrenResolved[1]
+        // eslint-disable-next-line
+        return childrenResolved[0] != childrenResolved[1]
 
       case '+':
         return childrenResolved.reduce((acc: number, child: number) => {
@@ -97,12 +104,7 @@ export default async function evaluateExpression(
         } catch {
           throw new Error('Invalid API query')
         }
-        let data
-        try {
-          data = await fetchAPIdata(urlWithQuery, params.APIfetch)
-        } catch {
-          throw new Error('Problem with API call')
-        }
+        const data = await fetchAPIdata(urlWithQuery, params.APIfetch)
         try {
           return extractAndSimplify(data, returnProperty)
         } catch {
@@ -142,7 +144,7 @@ async function processPgSQL(queryArray: any[], queryType: string, connection: IC
         return res.rows
     }
   } catch (err) {
-    return err
+    throw err
   }
 }
 
@@ -155,10 +157,14 @@ async function processGraphQL(queryArray: any[], connection: IGraphQLConnection)
     const variables = zipArraysToObject(variableNames, variableValues)
 
     const data = await graphQLquery(query, variables, connection)
-
-    return extractAndSimplify(data, returnProperty)
-  } catch {
-    throw new Error('GraphQL error')
+    if (!data) throw new Error('GraphQL query problem')
+    try {
+      return extractAndSimplify(data, returnProperty)
+    } catch (err) {
+      throw new Error('GraphQL -- unable to retrieve node')
+    }
+  } catch (err) {
+    throw new Error('GraphQL problem')
   }
 }
 

--- a/src/modules/expression-evaluator/src/types.ts
+++ b/src/modules/expression-evaluator/src/types.ts
@@ -29,7 +29,7 @@ export interface IQueryNode {
   value?: string | number | boolean | object
   type?: NodeType
   operator?: Operator
-  children?: Array<IQueryNode>
+  children?: Array<IQueryNode | string | boolean | number | null | undefined>
 }
 
 type NodeType = 'string' | 'number' | 'boolean' | 'array'

--- a/src/plugins/action_create_user/src/createUser.test.ts
+++ b/src/plugins/action_create_user/src/createUser.test.ts
@@ -1,6 +1,6 @@
 // Test suite for the createUser Action -- just confirms that users are written to database.
 
-import PostgresDB from '../../../components/postgresConnect'
+import DBConnect from '../../../components/databaseConnect'
 
 const Action = require('./createUser')
 
@@ -23,16 +23,23 @@ const invalidUser = {
 }
 
 test('Test: add User to database', () => {
-  return Action.createUser(testUser, PostgresDB).then((result: any) => {
+  return Action.createUser(testUser, DBConnect).then((result: any) => {
     expect(result).toEqual({
       status: 'Success',
       error_log: '',
+      output: {
+        email: 'test@sussol.net',
+        firstName: 'Carl',
+        lastName: 'Smith',
+        userId: 7,
+        username: 'ceejay',
+      },
     })
   })
 })
 
 test('Test: Invalid user (date_of_birth and username fields mis-named) -- should fail', () => {
-  return Action.createUser(invalidUser, PostgresDB).then((result: any) => {
+  return Action.createUser(invalidUser, DBConnect).then((result: any) => {
     expect(result).toEqual({
       status: 'Fail',
       error_log: 'There was a problem creating new user.',


### PR DESCRIPTION
Bunch of small fixes to expression-evaluator:

- #117 - uses loose equality now (`==`), so `null` equals `undefined`
- #58 - more specific GraphQL errors
- Improvements to GUI expression builder -- selector for "Development" or "Published" version of evaluator
- Better handling of literals in `children` array. So this is now valid:  
`{ operator: "=", children: [ "stringA", "stringA" ] } `
- Few extra tests to check the above
- Updated documentation