### PR TITLE
119 Better error handling for failed Actions

### DIFF
--- a/database/buildSchema/16_application.sql
+++ b/database/buildSchema/16_application.sql
@@ -2,7 +2,7 @@
 
 CREATE TYPE public.application_outcome AS ENUM ('Pending', 'Approved', 'Rejected');
 
-CREATE TYPE public.trigger as ENUM ('onApplicationCreate', 'onApplicationSubmit', 'onApplicationSave', 'onApplicationWithdrawn', 'onReviewStart', 'onReviewEditComment', 'onReviewSave', 'onReviewAssign', 'onApprovalSubmit', 'onScheduleTime', 'Processing');
+CREATE TYPE public.trigger as ENUM ('onApplicationCreate', 'onApplicationSubmit', 'onApplicationSave', 'onApplicationWithdrawn', 'onReviewStart', 'onReviewEditComment', 'onReviewSave', 'onReviewAssign', 'onApprovalSubmit', 'onScheduleTime', 'Processing', 'Error');
 
 CREATE TABLE public.application (
     id serial primary key,

--- a/database/buildSchema/23_action_queue.sql
+++ b/database/buildSchema/23_action_queue.sql
@@ -48,5 +48,5 @@ EXECUTE FUNCTION public.notify_action_queue();
 -- Note: couldn't put this in application file as it requires the trigger_queue table and function to be defined first
 CREATE TRIGGER application_trigger AFTER INSERT OR UPDATE OF trigger ON public.application
 FOR EACH ROW
-WHEN (NEW.trigger IS NOT NULL AND NEW.trigger <> 'Processing')
+WHEN (NEW.trigger IS NOT NULL AND NEW.trigger <> 'Processing' AND NEW.trigger <> 'Error')
 EXECUTE FUNCTION public.add_event_to_trigger_queue();

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -53,8 +53,13 @@ class PostgresDB {
           break
         case 'action_notifications':
           // For Async Actions only
-          executeAction(JSON.parse(payload), actionLibrary)
-          break
+          try {
+            executeAction(JSON.parse(payload), actionLibrary)
+          } catch (err) {
+            console.log(err.message)
+          } finally {
+            break
+          }
       }
     })
   }

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -153,12 +153,17 @@ class PostgresDB {
     }
   }
 
-  public resetTrigger = async (table: string, record_id: number): Promise<boolean> => {
-    const text = `UPDATE ${table} SET trigger = NULL WHERE id = $1`
+  public resetTrigger = async (
+    table: string,
+    record_id: number,
+    fail = false
+  ): Promise<boolean> => {
+    const triggerStatus = fail ? 'Error' : null
+    const text = `UPDATE ${table} SET trigger = $1 WHERE id = $2`
     try {
       const result = await this.query({
         text,
-        values: [record_id],
+        values: [triggerStatus, record_id],
       })
       return true
     } catch (err) {

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -42,7 +42,7 @@ class PostgresDB {
     listener.connect()
     listener.query('LISTEN trigger_notifications')
     listener.query('LISTEN action_notifications')
-    listener.on('notification', ({ channel, payload }) => {
+    listener.on('notification', async ({ channel, payload }) => {
       if (!payload) {
         console.log(`Notification ${channel} received with no payload!`)
         return
@@ -54,7 +54,7 @@ class PostgresDB {
         case 'action_notifications':
           // For Async Actions only
           try {
-            executeAction(JSON.parse(payload), actionLibrary)
+            await executeAction(JSON.parse(payload), actionLibrary)
           } catch (err) {
             console.log(err.message)
           } finally {

--- a/src/components/triggersAndActions.ts
+++ b/src/components/triggersAndActions.ts
@@ -154,6 +154,7 @@ export async function processTrigger(payload: TriggerPayload) {
       continue
     }
     try {
+      console.log('Success')
       const actionPayload = {
         id: action.id,
         code: action.action_code,
@@ -164,12 +165,13 @@ export async function processTrigger(payload: TriggerPayload) {
       outputCumulative = { ...outputCumulative, ...result.output }
       if (result.status === 'Fail') console.log(result.error_log)
     } catch (err) {
+      console.log('Fail')
       actionFailed.fail = true
       actionFailed.action = action.action_code
     }
   }
-  // After all done, set Trigger on table back to NULL
-  DBConnect.resetTrigger(table, record_id)
+  // After all done, set Trigger on table back to NULL (or Error)
+  DBConnect.resetTrigger(table, record_id, actionFailed.fail)
 }
 
 async function evaluateParameters(
@@ -215,8 +217,7 @@ export async function executeAction(
       id: payload.id,
     })
   } catch (err) {
-    console.error('>> Error executing action:', payload.code)
-    console.log('Cancelling subsequent Actions...')
+    // console.error('>> Error executing action:', payload.code)
     await DBConnect.executedActionStatusUpdate({
       status: 'Fail',
       error_log: "Couldn't execute Action",

--- a/src/components/triggersAndActions.ts
+++ b/src/components/triggersAndActions.ts
@@ -154,7 +154,6 @@ export async function processTrigger(payload: TriggerPayload) {
       continue
     }
     try {
-      console.log('Success')
       const actionPayload = {
         id: action.id,
         code: action.action_code,
@@ -165,7 +164,6 @@ export async function processTrigger(payload: TriggerPayload) {
       outputCumulative = { ...outputCumulative, ...result.output }
       if (result.status === 'Fail') console.log(result.error_log)
     } catch (err) {
-      console.log('Fail')
       actionFailed.fail = true
       actionFailed.action = action.action_code
     }
@@ -217,10 +215,10 @@ export async function executeAction(
       id: payload.id,
     })
   } catch (err) {
-    // console.error('>> Error executing action:', payload.code)
+    console.error('>> Error executing action:', payload.code)
     await DBConnect.executedActionStatusUpdate({
       status: 'Fail',
-      error_log: "Couldn't execute Action",
+      error_log: "Couldn't execute Action: " + err.message,
       parameters_evaluated: null,
       output: null,
       id: payload.id,

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -14034,7 +14034,8 @@ export enum Trigger {
   OnReviewAssign = 'ON_REVIEW_ASSIGN',
   OnApprovalSubmit = 'ON_APPROVAL_SUBMIT',
   OnScheduleTime = 'ON_SCHEDULE_TIME',
-  Processing = 'PROCESSING'
+  Processing = 'PROCESSING',
+  Error = 'ERROR'
 }
 
 /** A filter to be used against Trigger fields. All fields are combined with a logical ‘and.’ */

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,9 +56,9 @@ export interface ActionQueueGetPayload {
 export interface ActionQueueExecutePayload {
   id: number
   error_log: string
-  parameters_evaluated: { [key: string]: any }
+  parameters_evaluated: { [key: string]: any } | null
   status: ActionQueueStatus
-  output: BasicObject
+  output: BasicObject | null
 }
 
 export interface ActionApplicationData {


### PR DESCRIPTION
Fixes #119.

The simplest way to force an error situation is to use the current front-end `master` (Commit: f6bdeb9) and submit the UserRego application without filling in any content. (This won't be possible after validation checking is merged to master)

Previously, after an Action failure, an unhandled error was thrown, meaning the `processTrigger` method was aborted and so the Trigger on the application table was being stuck perpetually in "Processing"

The changes here achieve the following:
- Better error handling in back-end: Error messages are written to the action_queue `error_log` and the `processTrigger` method does not abort
- On failure of a sequential action, any subsequent Actions are cancelled, with a "Cancellation" message written to their record in the action_queue.
- The Trigger field on the triggering table is set to (a new value) "Error". This way the front-end will behave as before (perpetual loading due to "Not NULL" trigger), but with the potential to handle error state differently when we want to implement this.

To test, submit UserRego form with no user details provided. Note the errors printed to console, and check the `error_log`s in the action_queue table. Also, note the Trigger is set to 'Error' state.