### PR TITLE
#135 new review test template & application

### DIFF
--- a/database/buildSchema/07_template.sql
+++ b/database/buildSchema/07_template.sql
@@ -8,5 +8,5 @@ CREATE TABLE public.template (
 	code varchar NOT NULL,
 is_linear boolean DEFAULT true,
     status public.template_status,
-    version_timestamp timestamp   
+    version_timestamp timestamptz   
 );

--- a/database/buildSchema/19_application_status_history.sql
+++ b/database/buildSchema/19_application_status_history.sql
@@ -6,7 +6,7 @@ CREATE TABLE public.application_status_history (
     id serial primary key,
     application_stage_history_id integer references public.application_stage_history(id),
     status public.application_status,
-    time_created timestamp with time zone,
+    time_created timestamp default current_timestamp,
     is_current bool DEFAULT true
 );
 

--- a/database/buildSchema/19_application_status_history.sql
+++ b/database/buildSchema/19_application_status_history.sql
@@ -6,7 +6,7 @@ CREATE TABLE public.application_status_history (
     id serial primary key,
     application_stage_history_id integer references public.application_stage_history(id),
     status public.application_status,
-    time_created timestamp default current_timestamp,
+    time_created timestamptz default current_timestamp,
     is_current bool DEFAULT true
 );
 

--- a/database/buildSchema/21_application_response.sql
+++ b/database/buildSchema/21_application_response.sql
@@ -6,5 +6,5 @@ CREATE TABLE public.application_response (
     application_id integer references public.application(id),
     value jsonb,
     is_valid boolean,
-    timestamp timestamp default current_timestamp
+    timestamp timestamptz default current_timestamp
 );

--- a/database/buildSchema/21_application_response.sql
+++ b/database/buildSchema/21_application_response.sql
@@ -6,5 +6,5 @@ CREATE TABLE public.application_response (
     application_id integer references public.application(id),
     value jsonb,
     is_valid boolean,
-    time_created timestamp with time zone
+    timestamp timestamp default current_timestamp
 );

--- a/database/buildSchema/22_trigger_queue.sql
+++ b/database/buildSchema/22_trigger_queue.sql
@@ -7,7 +7,7 @@ CREATE TABLE public.trigger_queue (
     trigger_type public.trigger,
     "table" varchar,
     record_id int,
-    timestamp timestamp,
+    timestamp timestamptz,
     status public.trigger_queue_status,
     log jsonb
 );

--- a/database/buildSchema/24_action_queue.sql
+++ b/database/buildSchema/24_action_queue.sql
@@ -13,9 +13,9 @@ CREATE TABLE public.action_queue (
     parameters_evaluated jsonb,
     status public.action_queue_status,
     output jsonb,
-    time_queued timestamp,
-    time_completed timestamp,
-    time_scheduled timestamp,
+    time_queued timestamptz,
+    time_completed timestamptz,
+    time_scheduled timestamptz,
     error_log varchar
 );
 

--- a/database/initialise_database.sh
+++ b/database/initialise_database.sh
@@ -20,3 +20,6 @@ wait $PID
 
 echo "Generating types file..."
 yarn generate
+
+# This forces server to restart
+touch "./src/server.ts"

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -1491,7 +1491,7 @@ const queries = [
                       elementTypePluginCode: "shortText"
                       category: QUESTION
                       isRequired: false
-                      parameters: { label: "Please list any side effect" }
+                      parameters: { label: "Please list any side effects" }
                     }
                   ]
                 }
@@ -1606,6 +1606,21 @@ const queries = [
     createUser(
       input: {
         user: { email: "valerio@nra.org", passwordHash: "7110EDA4D09E062AA5E4A390B0A572AC0D2C0220", username: "valerio" }
+      }
+    ) {
+      user {
+        email
+        passwordHash
+        username
+      }
+    }
+  }`,
+  `mutation {
+    createUser(
+      input: {
+        user: { email: "js@nowhere.com", passwordHash: "123456", username: "js",
+        firstName: "John", lastName: "Smith"
+       }
       }
     ) {
       user {
@@ -1931,6 +1946,75 @@ const queries = [
         }
         user {
           username
+        }
+      }
+    }
+  }`,
+  `mutation ReviewTestApplication {
+    createApplication(
+      input: {
+        application: {
+          serial: "12345"
+          applicationSectionsUsingId: {
+            create: [{ templateSectionId: 6 }, { templateSectionId: 7 }]
+          }
+          name: "Test Review -- Vitamin C"
+          outcome: PENDING
+          templateId: 4
+          userId: 5
+          applicationStageHistoriesUsingId: {
+            create: {
+              isCurrent: true
+              templateStageToStageId: { connectById: { id: 5 } }
+              applicationStatusHistoriesUsingId: {
+                create: { isCurrent: true, status: SUBMITTED }
+              }
+            }
+          }
+          applicationResponsesUsingId: {
+            create: [
+              { isValid: null, value: null, templateElementId: 39 }
+              { isValid: true, templateElementId: 40, value: { text: "John" } }
+              { isValid: true, templateElementId: 41, value: { text: "Smith" } }
+              {
+                isValid: true
+                templateElementId: 42
+                value: { text: "js@nowhere.com" }
+              }
+              { isValid: null, value: null, templateElementId: 43 }
+              { isValid: true, templateElementId: 44, value: { text: "39" } }
+              {
+                isValid: true
+                templateElementId: 45
+                value: { text: "New Zealand" }
+              }
+              { isValid: null, value: null, templateElementId: 46 }
+              {
+                isValid: true
+                templateElementId: 47
+                value: { text: "Vitamin C" }
+              }
+              {
+                isValid: true
+                templateElementId: 48
+                value: { text: "Natural Product", optionIndex: 1 }
+              }
+              { isValid: null, value: null, templateElementId: 49 }
+              { isValid: true, templateElementId: 50, value: { text: "50mg" } }
+              { isValid: true, templateElementId: 51, value: { text: "100" } }
+              {
+                isValid: true
+                templateElementId: 52
+                value: { text: "Turning orange" }
+              }
+            ]
+          }
+        }
+      }
+    ) {
+      query {
+        applicationBySerial(serial: "12345") {
+          id
         }
       }
     }

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -1428,37 +1428,30 @@ const queries = [
           applicationResponsesUsingId: {
             create: [
               {
-                timeCreated: "NOW()"
                 value: { text: "Craig" }
                 templateElementToTemplateElementId: { connectById: { id: 2 } }
               }
               {
-                timeCreated: "NOW()"
                 value: { text: "Drown" }
                 templateElementToTemplateElementId: { connectById: { id: 3 } }
               }
               {
-                timeCreated: "NOW()"
                 value: { text: "c_drown" }
                 templateElementToTemplateElementId: { connectById: { id: 4 } }
               }
               {
-                timeCreated: "NOW()"
                 value: { text: "craig@sussol.net" }
                 templateElementToTemplateElementId: { connectById: { id: 5 } }
               }
               {
-                timeCreated: "NOW()"
                 value: { text: "7110EDA4D09E062AA5E4A390B0A572AC0D2C0220" }
                 templateElementToTemplateElementId: { connectById: { id: 6 } }
               }
               {
-                timeCreated: "NOW()"
                 value: { optionIndex: 0, text: "Manufacturer" }
                 templateElementToTemplateElementId: { connectById: { id: 8 } }
               }
               {
-                timeCreated: "NOW()"
                 value: { optionIndex: 1, text: "Manufacturer B" }
                 templateElementToTemplateElementId: { connectById: { id: 9 } }
               }
@@ -1535,37 +1528,30 @@ const queries = [
           applicationResponsesUsingId: {
             create: [
               {
-                  timeCreated: "NOW()"
                   value: { text: "Carl" }
                   templateElementToTemplateElementId: { connectById: { id: 2 } }
                 }
                 {
-                  timeCreated: "NOW()"
                   value: { text: "Smith" }
                   templateElementToTemplateElementId: { connectById: { id: 3 } }
                 }
                 {
-                  timeCreated: "NOW()"
                   value: { text: "cjsmith" }
                   templateElementToTemplateElementId: { connectById: { id: 4 } }
                 }
                 {
-                  timeCreated: "NOW()"
                   value: { text: "carl@sussol.net" }
                   templateElementToTemplateElementId: { connectById: { id: 5 } }
                 }
                 {
-                  timeCreated: "NOW()"
                   value: { text: "7110EDA4D09E062AA5E4A390B0A572AC0D2C0220" }
                   templateElementToTemplateElementId: { connectById: { id: 6 } }
                 }
                 {
-                  timeCreated: "NOW()"
                   value: { optionIndex: 0, text: "Importer" }
                   templateElementToTemplateElementId: { connectById: { id: 8 } }
                 }
                 {
-                  timeCreated: "NOW()"
                   value: { optionIndex: 1, text: "Importer A" }
                   templateElementToTemplateElementId: { connectById: { id: 9 } }
                 }
@@ -1649,12 +1635,10 @@ const queries = [
           applicationResponsesUsingId: {
             create: [
               {
-                timeCreated: "NOW()"
                 value: {text: "Company C"}
                 templateElementToTemplateElementId: { connectById: { id: 12 } }
               }
               {
-                timeCreated: "NOW()"
                 value: {option: 2}
                 templateElementToTemplateElementId: { connectById: { id: 13 } }
               }

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -2012,10 +2012,8 @@ const queries = [
         }
       }
     ) {
-      query {
-        applicationBySerial(serial: "12345") {
-          id
-        }
+      application {
+        name
       }
     }
   }`,

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -1299,6 +1299,267 @@ const queries = [
       }
     }
   }`,
+  // Simple template for testing Review process
+  `mutation {
+    createTemplate(
+      input: {
+        template: {
+          code: "ReviewTest"
+          name: "Test -- Review Process"
+          status: AVAILABLE
+          versionTimestamp: "NOW()"
+          templateSectionsUsingId: {
+            create: [
+              {
+                code: "S1"
+                title: "Personal Info"
+                index: 0
+                templateElementsUsingId: {
+                  create: [
+                    {
+                      code: "Text1"
+                      index: 0
+                      title: "Intro"
+                      elementTypePluginCode: "textInfo"
+                      category: INFORMATION
+                      parameters: {
+                        text: "In this section, we require your **personal information**"
+                      }
+                    }
+                    {
+                      code: "Q1"
+                      index: 1
+                      title: "First Name"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      parameters: { label: "First Name" }
+                    }
+                    {
+                      code: "Q2"
+                      index: 2
+                      title: "Last Name"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      parameters: { label: "Last Name" }
+                    }
+                    {
+                      code: "Q3"
+                      index: 3
+                      title: "Email"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      parameters: {
+                        label: "Email"
+                        validation: {
+                          operator: "REGEX"
+                          children: [
+                            {
+                              operator: "objectProperties"
+                              children: [{ value: { property: "thisResponse" } }]
+                            }
+                            {
+                              value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
+                            }
+                          ]
+                        }
+                        validationMessage: "Not a valid email address"
+                      }
+                    }
+                    {
+                      code: "PB1"
+                      index: 4
+                      title: "Page Break"
+                      elementTypePluginCode: "pageBreak"
+                      category: INFORMATION
+                    }
+                    {
+                      code: "Q4"
+                      index: 5
+                      title: "Age"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      isRequired: false
+                      parameters: {
+                        label: "Age"
+                        validation: {
+                          operator: "REGEX"
+                          children: [
+                            {
+                              operator: "objectProperties"
+                              children: [{ value: { property: "thisResponse" } }]
+                            }
+                            { value: "^[0-9]+$" }
+                          ]
+                        }
+                        validationMessage: "Response must be a number"
+                      }
+                    }
+                    {
+                      code: "Q5"
+                      index: 6
+                      title: "Nationality"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      parameters: {
+                        label: "Nationality"
+                        placeholder: "Enter a country"
+                      }
+                    }
+                  ]
+                }
+              }
+              {
+                code: "S2"
+                title: "Product Info"
+                index: 7
+                templateElementsUsingId: {
+                  create: [
+                    {
+                      code: "Text2"
+                      index: 0
+                      title: "Product Intro"
+                      elementTypePluginCode: "textInfo"
+                      category: INFORMATION
+                      parameters: {
+                        text: "In this section, we require your **PRODUCT information**"
+                      }
+                    }
+                    {
+                      code: "Q20"
+                      index: 8
+                      title: "Product Name"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      parameters: { label: "Name of Product" }
+                    }
+                    {
+                      code: "Q21"
+                      index: 9
+                      title: "Product Type"
+                      elementTypePluginCode: "dropdownChoice"
+                      category: QUESTION
+                      parameters: {
+                        label: "What type of product are you registering?"
+                        placeholder: "Select"
+                        options: ["Medicine", "Natural Product"]
+                      }
+                    }
+                    {
+                      code: "PB2"
+                      index: 10
+                      title: "Page Break"
+                      elementTypePluginCode: "pageBreak"
+                      category: INFORMATION
+                    }
+                    {
+                      code: "Q22"
+                      index: 11
+                      title: "Dose Size"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      parameters: {
+                        label: "Size of single dose"
+                        placeholder: "Metric units please"
+                      }
+                    }
+                    {
+                      code: "Q23"
+                      index: 12
+                      title: "Packet Size"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      parameters: {
+                        label: "How many doses per packet?"
+                        placeholder: "Whole number"
+                        validation: {
+                          operator: "REGEX"
+                          children: [
+                            {
+                              operator: "objectProperties"
+                              children: [{ value: { property: "thisResponse" } }]
+                            }
+                            { value: "^[0-9]+$" }
+                          ]
+                        }
+                        validationMessage: "Must be a number"
+                      }
+                    }
+                    {
+                      code: "Q24"
+                      index: 13
+                      title: "Side Effects"
+                      elementTypePluginCode: "shortText"
+                      category: QUESTION
+                      isRequired: false
+                      parameters: { label: "Please list any side effect" }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+          templateStagesUsingId: {
+            create: [
+              { number: 1, title: "Screening" }
+              { number: 2, title: "Assessment" }
+            ]
+          }
+          templateActionsUsingId: {
+            create: [
+              {
+                actionCode: "incrementStage"
+                trigger: ON_APPLICATION_CREATE
+                parameterQueries: {
+                  applicationId: {
+                    operator: "objectProperties"
+                    children: [{ value: { property: "applicationId" } }]
+                  }
+                }
+              }
+              {
+                actionCode: "changeStatus"
+                trigger: ON_APPLICATION_SUBMIT
+                sequence: 1
+                parameterQueries: {
+                  applicationId: {
+                    operator: "objectProperties"
+                    children: [{ value: { property: "applicationId" } }]
+                  }
+                  newStatus: { value: "Submitted" }
+                }
+              }
+              {
+                actionCode: "cLog"
+                trigger: ON_APPLICATION_SUBMIT
+                sequence: 2
+                parameterQueries: { message: "Application Submitted" }
+              }
+            ]
+          }
+        }
+      }
+    ) {
+      template {
+        code
+        name
+        templateSections {
+          nodes {
+            code
+            title
+            templateElementsBySectionId {
+              nodes {
+                code
+                visibilityCondition
+                parameters
+                title
+                category
+              }
+            }
+          }
+        }
+      }
+    }
+  }`,
   //   Add some users
   `mutation {
         createUser(

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -1411,7 +1411,7 @@ const queries = [
               {
                 code: "S2"
                 title: "Product Info"
-                index: 7
+                index: 1
                 templateElementsUsingId: {
                   create: [
                     {
@@ -1426,7 +1426,7 @@ const queries = [
                     }
                     {
                       code: "Q20"
-                      index: 8
+                      index: 1
                       title: "Product Name"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
@@ -1434,7 +1434,7 @@ const queries = [
                     }
                     {
                       code: "Q21"
-                      index: 9
+                      index: 2
                       title: "Product Type"
                       elementTypePluginCode: "dropdownChoice"
                       category: QUESTION
@@ -1446,14 +1446,14 @@ const queries = [
                     }
                     {
                       code: "PB2"
-                      index: 10
+                      index: 3
                       title: "Page Break"
                       elementTypePluginCode: "pageBreak"
                       category: INFORMATION
                     }
                     {
                       code: "Q22"
-                      index: 11
+                      index: 4
                       title: "Dose Size"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
@@ -1464,7 +1464,7 @@ const queries = [
                     }
                     {
                       code: "Q23"
-                      index: 12
+                      index: 5
                       title: "Packet Size"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
@@ -1486,7 +1486,7 @@ const queries = [
                     }
                     {
                       code: "Q24"
-                      index: 13
+                      index: 6
                       title: "Side Effects"
                       elementTypePluginCode: "shortText"
                       category: QUESTION

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -254,7 +254,7 @@ class PostgresDB {
     FROM application_response JOIN template_element
     ON template_element.id = application_response.template_element_id
     WHERE application_id = $1
-    ORDER BY code, time_created DESC
+    ORDER BY code, timestamp DESC
     `
     const result = await this.query({ text, values: [applicationId] })
     const responses = result.rows

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1053,7 +1053,7 @@ export type ApplicationResponse = Node & {
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   /** Reads a single `TemplateElement` that is related to this `ApplicationResponse`. */
   templateElement?: Maybe<TemplateElement>;
   /** Reads a single `Application` that is related to this `ApplicationResponse`. */
@@ -1114,7 +1114,7 @@ export type ApplicationResponseApplicationIdFkeyApplicationResponseCreateInput =
   templateElementId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -1190,8 +1190,8 @@ export type ApplicationResponseCondition = {
   value?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `isValid` field. */
   isValid?: Maybe<Scalars['Boolean']>;
-  /** Checks for equality with the object’s `timeCreated` field. */
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `timestamp` field. */
+  timestamp?: Maybe<Scalars['Datetime']>;
 };
 
 /** A filter to be used against `ApplicationResponse` object types. All fields are combined with a logical ‘and.’ */
@@ -1206,8 +1206,8 @@ export type ApplicationResponseFilter = {
   value?: Maybe<JsonFilter>;
   /** Filter by the object’s `isValid` field. */
   isValid?: Maybe<BooleanFilter>;
-  /** Filter by the object’s `timeCreated` field. */
-  timeCreated?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `timestamp` field. */
+  timestamp?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `reviewResponses` relation. */
   reviewResponses?: Maybe<ApplicationResponseToManyReviewResponseFilter>;
   /** Some related `reviewResponses` exist. */
@@ -1239,7 +1239,7 @@ export type ApplicationResponseInput = {
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -1325,7 +1325,7 @@ export type ApplicationResponsePatch = {
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -1367,8 +1367,8 @@ export enum ApplicationResponsesOrderBy {
   ValueDesc = 'VALUE_DESC',
   IsValidAsc = 'IS_VALID_ASC',
   IsValidDesc = 'IS_VALID_DESC',
-  TimeCreatedAsc = 'TIME_CREATED_ASC',
-  TimeCreatedDesc = 'TIME_CREATED_DESC',
+  TimestampAsc = 'TIMESTAMP_ASC',
+  TimestampDesc = 'TIMESTAMP_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -1379,7 +1379,7 @@ export type ApplicationResponseTemplateElementIdFkeyApplicationResponseCreateInp
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -5685,7 +5685,7 @@ export type FileApplicationResponseIdFkeyApplicationResponseCreateInput = {
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -10161,7 +10161,7 @@ export type ReviewResponseApplicationResponseIdFkeyApplicationResponseCreateInpu
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -14674,7 +14674,7 @@ export type UpdateApplicationResponseOnApplicationResponseForApplicationResponse
   templateElementId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -14687,7 +14687,7 @@ export type UpdateApplicationResponseOnApplicationResponseForApplicationResponse
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -14701,7 +14701,7 @@ export type UpdateApplicationResponseOnFileForFileApplicationResponseIdFkeyPatch
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -14715,7 +14715,7 @@ export type UpdateApplicationResponseOnReviewResponseForReviewResponseApplicatio
   applicationId?: Maybe<Scalars['Int']>;
   value?: Maybe<Scalars['JSON']>;
   isValid?: Maybe<Scalars['Boolean']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
+  timestamp?: Maybe<Scalars['Datetime']>;
   templateElementToTemplateElementId?: Maybe<ApplicationResponseTemplateElementIdFkeyInput>;
   applicationToApplicationId?: Maybe<ApplicationResponseApplicationIdFkeyInput>;
   reviewResponsesUsingId?: Maybe<ReviewResponseApplicationResponseIdFkeyInverseInput>;
@@ -20005,7 +20005,7 @@ export type ApplicationResponseResolvers<ContextType = any, ParentType extends R
   applicationId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   value?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   isValid?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  timeCreated?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
+  timestamp?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
   templateElement?: Resolver<Maybe<ResolversTypes['TemplateElement']>, ParentType, ContextType>;
   application?: Resolver<Maybe<ResolversTypes['Application']>, ParentType, ContextType>;
   reviewResponses?: Resolver<ResolversTypes['ReviewResponsesConnection'], ParentType, ContextType, RequireFields<ApplicationResponseReviewResponsesArgs, 'orderBy'>>;


### PR DESCRIPTION
Implements #135.

_Requires [front-end PR #195](https://github.com/openmsupply/application-manager-web-app/pull/195) to make timestamp fields match, and new template to appear in sidebar._

Added new "ReviewTest" template, with submitted application form into database. Application appears in Application List -- named "Test Review -- Vitamin C"

Also:
- Changed "time_created" in "application_response" to "timestamp", and set a default value of current time, which should also close [front-end issue #172](https://github.com/openmsupply/application-manager-web-app/issues/172).
- Added additional `touch` command to `initialise_database.sh` to force the server to restart after a database init.