### PR TITLE
#136 Assign application to reviewer

### DIFF
--- a/database/insertData.js
+++ b/database/insertData.js
@@ -2054,6 +2054,40 @@ const queries = [
       }
     }
   }`,
+  // Assign above application to reviewer (all questions)
+  `mutation {
+    createReviewAssignment(
+      input: {
+        reviewAssignment: {
+          applicationId: 4
+          assignerId: 7
+          reviewerId: 6
+          stageId: 5
+          reviewQuestionAssignmentsUsingId: {
+            create: [
+              { templateElementId: 43 }
+              { templateElementId: 44 }
+              { templateElementId: 45 }
+              { templateElementId: 47 }
+              { templateElementId: 48 }
+              { templateElementId: 49 }
+              { templateElementId: 50 }
+              { templateElementId: 51 }
+              { templateElementId: 53 }
+              { templateElementId: 54 }
+              { templateElementId: 55 }
+            ]
+          }
+        }
+      }
+    ) {
+      reviewAssignment {
+        application {
+          name
+        }
+      }
+    }
+  }`,
   // Non Registered User Permissions
   `mutation {
     createUser(

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -1986,6 +1986,7 @@ const queries = [
       }
     }
   }`,
+  // Application for Review Testing
   `mutation ReviewTestApplication {
     createApplication(
       input: {


### PR DESCRIPTION
Addresses #136. Updated `insertData.js` to create a review assignment of the new "Vitamin C" test review application.

Created two new users as well ("Reviewer" and "Assigner") -- unfortunately I accidentally pushed them to master before I realised what branch I was on (Ooops 😖), so you won't see them in this diff, but its line 1641–1668.

Once you've run the database setup script, you can see the details of the review assignment and the questions assigned (all of them) using the following GraphQL query:
```
query ShowReviewAssignment {
  reviewAssignment(id: 1) {
    application {
      name
      user {
        firstName
        lastName
      }
    }
    assigner {
      firstName
      lastName
    }
    reviewer {
      firstName
      lastName
    }
    reviewQuestionAssignments {
      nodes {
        templateElement {
          title
        }
      }
      totalCount
    }
  }
}
```

Question: I've currently only assigned questions that are actual "questions" rather than textInfo or pageBreak. Do you think this is the way to go, or will assigning a Section just assign everything regardless of its type and we filter in the front-end?