### PR TITLE
#194F validation updates

### DIFF
--- a/database/buildSchema/14_template_element.sql
+++ b/database/buildSchema/14_template_element.sql
@@ -9,9 +9,11 @@ CREATE TABLE public.template_element (
     index integer,
     title varchar,
     category public.template_element_category,
-    visibility_condition jsonb DEFAULT '{"value":true}'::jsonb,
     element_type_plugin_code varchar,
+    visibility_condition jsonb DEFAULT '{"value":true}'::jsonb,
     is_required jsonb DEFAULT '{"value":true}'::jsonb,
     is_editable jsonb DEFAULT '{"value":true}'::jsonb,
+    validation jsonb DEFAULT '{"value":true}'::jsonb,
+    validation_message varchar,
     parameters jsonb
 );

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -48,6 +48,32 @@ const queries = [
                       title: "Last Name"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      validation: {
+                        operator: "AND"
+                        children: [
+                          {
+                            operator: "!="
+                            children: [
+                              {
+                                operator: "objectProperties"
+                                children: [{ value: { property: "Q1.text" } }]
+                              }
+                              { value: null }
+                            ]
+                          }
+                          {
+                            operator: "!="
+                            children: [
+                              {
+                                operator: "objectProperties"
+                                children: [{ value: { property: "Q1.text" } }]
+                              }
+                              { value: "" }
+                            ]
+                          }
+                        ]
+                      }
+                      validationMessage: "You need a first name."
                       parameters: {
                         label: {
                           operator: "CONCAT"
@@ -59,32 +85,6 @@ const queries = [
                             ", what is your last name?"
                           ]
                         }
-                        validation: {
-                          operator: "AND"
-                          children: [
-                            {
-                              operator: "!="
-                              children: [
-                                {
-                                  operator: "objectProperties"
-                                  children: [{ value: { property: "Q1.text" } }]
-                                }
-                                { value: null }
-                              ]
-                            }
-                            {
-                              operator: "!="
-                              children: [
-                                {
-                                  operator: "objectProperties"
-                                  children: [{ value: { property: "Q1.text" } }]
-                                }
-                                { value: "" }
-                              ]
-                            }
-                          ]
-                        }
-                        validationMessage: "You need a first name."
                       }
                     }
                     {
@@ -128,23 +128,21 @@ const queries = [
                           { value: "" }
                         ]
                       }
-                      parameters: {
-                        label: "Select a username"
-                        validation: {
-                          operator: "API"
-                          children: [
-                            { value: "http://localhost:8080/check-unique" }
-                            { value: ["type", "value"] }
-                            { value: "username" }
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            { value: "unique" }
-                          ]
-                        }
-                        validationMessage: "Username must be unique"
+                      validation: {
+                        operator: "API"
+                        children: [
+                          { value: "http://localhost:8080/check-unique" }
+                          { value: ["type", "value"] }
+                          { value: "username" }
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: "unique" }
+                        ]
                       }
+                      validationMessage: "Username must be unique"
+                      parameters: { label: "Select a username" }
                     }
                     {
                       code: "Q4"
@@ -152,22 +150,20 @@ const queries = [
                       title: "Email"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: {
-                        label: "Email"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            {
-                              value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
-                            }
-                          ]
-                        }
-                        validationMessage: "Not a valid email address"
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          {
+                            value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
+                          }
+                        ]
                       }
+                      validationMessage: "Not a valid email address"
+                      parameters: { label: "Email" }
                     }
                     {
                       code: "Q5"
@@ -175,23 +171,23 @@ const queries = [
                       title: "Password"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: "^[\\\\S]{8,}$" }
+                        ]
+                      }
+                      validationMessage: "Password must be at least 8 characters"
+                      # Validation:Currently just checks 8 chars, needs more complexity
                       parameters: {
                         label: "Password"
                         maskedInput: true
                         placeholder: "Password must be at least 8 chars long"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            { value: "^[\\\\S]{8,}$" }
-                          ]
-                        }
-                        validationMessage: "Password must be at least 8 characters"
                       }
-                      # Validation:Currently just checks 8 chars, needs more complexity
                     }
                     {
                       code: "Q5B"
@@ -225,7 +221,6 @@ const queries = [
                             }
                           ]
                         }
-                        validation: { value: true }
                       }
                       isRequired: false
                     }
@@ -276,7 +271,6 @@ const queries = [
                           "Manufacturer B"
                           "Manufacturer C"
                         ]
-                        validation: { value: true }
                       }
                     }
                     {
@@ -304,7 +298,6 @@ const queries = [
                           "Distributor B"
                           "Distributor C"
                         ]
-                        validation: { value: true }
                       }
                       isRequired: false
                     }
@@ -329,7 +322,6 @@ const queries = [
                         label: "Select Importer"
                         placeholder: "Select"
                         options: ["Importer A", "Importer B", "Importer C"]
-                        validation: { value: true }
                       }
                       isRequired: false
                     }
@@ -352,7 +344,6 @@ const queries = [
                             { value: "name" }
                           ]
                         }
-                        validation: { value: true }
                       }
                       isRequired: false
                     }
@@ -624,51 +615,27 @@ const queries = [
                         title: "Company details"
                         text: "The details entered should match with your registered company documents attached."
                       }
-                    },
+                    }
                     {
                       code: "S1Q1"
                       index: 1
                       title: "Organisation Name"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { 
-                        label: "Unique Name for Company",
-                        validation: {
-                          operator:"AND",
-                          children: [
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value:null }
-                              ]
-                            },
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value: "" }
-                              ]
-                            }
-                          ]
-                        }
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: ".+" }
+                        ]
                       }
                       # Validation TO-DO: must be unique in system
-                    },
+                      validationMessage: "Cannot be blank"
+                      parameters: { label: "Unique Name for Company" }
+                    }
                     {
                       code: "S1Q2"
                       index: 2
@@ -677,20 +644,16 @@ const queries = [
                       category: QUESTION
                       parameters: {
                         label: "Select type of activity"
-                        options: [
-                          "Manufacturer",
-                          "Importer",
-                          "Producer"
-                        ]
+                        options: ["Manufacturer", "Importer", "Producer"]
                       }
-                    },
+                    }
                     {
                       code: "S1PB1"
                       index: 3
                       title: "Page Break"
                       elementTypePluginCode: "pageBreak"
                       category: INFORMATION
-                    },
+                    }
                     {
                       code: "S1T2"
                       index: 4
@@ -698,7 +661,7 @@ const queries = [
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
                       parameters: { title: "Company nationality" }
-                    },
+                    }
                     {
                       code: "S1Q3"
                       index: 5
@@ -707,12 +670,9 @@ const queries = [
                       category: QUESTION
                       parameters: {
                         label: "Select the nationality of this company:"
-                        options: [
-                          "National",
-                          "International"
-                        ]
+                        options: ["National", "International"]
                       }
-                    },
+                    }
                     {
                       code: "S1Q4"
                       index: 6
@@ -729,15 +689,13 @@ const queries = [
                           { value: "International" }
                         ]
                       }
-                      parameters: {
-                        label: "Upload your valid import permit"
-                      }
+                      parameters: { label: "Upload your valid import permit" }
                       isRequired: false
                     }
                   ]
                 }
               }
-              { 
+              {
                 code: "S2"
                 title: "Section 2"
                 index: 1
@@ -760,49 +718,25 @@ const queries = [
                           { value: "National" }
                         ]
                       }
-                    },
+                    }
                     {
                       code: "S2Q1"
                       index: 1
                       title: "Organisation Street"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { 
-                        label: "Enter the company street",
-                        validation: {
-                          operator:"AND",
-                          children: [
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value:null }
-                              ]
-                            },
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value: "" }
-                              ]
-                            }
-                          ]
-                        }
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: ".+" }
+                        ]
                       }
+                      validationMessage: "Cannot be blank"
+                      parameters: { label: "Enter the company street" }
                       visibilityCondition: {
                         operator: "="
                         children: [
@@ -813,49 +747,25 @@ const queries = [
                           { value: "National" }
                         ]
                       }
-                    },
+                    }
                     {
                       code: "S2Q2"
                       index: 2
                       title: "Organisation region"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { 
-                        label: "Enter the company region",
-                        validation: {
-                          operator:"AND",
-                          children: [
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value:null }
-                              ]
-                            },
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value: "" }
-                              ]
-                            }
-                          ]
-                        }
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: ".+" }
+                        ]
                       }
+                      validationMessage: "Cannot be blank"
+                      parameters: { label: "Enter the company region" }
                       visibilityCondition: {
                         operator: "="
                         children: [
@@ -866,124 +776,64 @@ const queries = [
                           { value: "National" }
                         ]
                       }
-                    },
+                    }
                     {
                       code: "S2PB1"
                       index: 3
                       title: "Page Break"
                       elementTypePluginCode: "pageBreak"
                       category: INFORMATION
-                      visibilityCondition: {
-                        operator: "="
-                        children: [
-                          {
-                            operator: "objectProperties"
-                            children: [{ value: { property: "S1Q3.text" } }]
-                          }
-                          { value: "National" }
-                        ]
-                      }
-                    },
+                    }
                     {
                       code: "S2T2"
                       index: 4
                       title: "Intro Section 2 - Page 2/2"
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
-                      parameters: {
-                        title: "Company bank account"
-                      }
-                    },
+                      parameters: { title: "Company bank account" }
+                    }
                     {
                       code: "S2Q3"
                       index: 5
                       title: "Billing account"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { 
-                        label: "Enter the company billing account",
-                        validation: {
-                          operator:"AND",
-                          children: [
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value:null }
-                              ]
-                            },
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value: "" }
-                              ]
-                            }
-                          ]
-                        }
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: ".+" }
+                        ]
                       }
-                    },
+                      validationMessage: "Cannot be blank"
+                      parameters: { label: "Enter the company billing account" }
+                    }
                     {
                       code: "S2Q4"
                       index: 4
                       title: "Name of account"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: { 
-                        label: "Enter the company acount name",
-                        validation: {
-                          operator:"AND",
-                          children: [
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value:null }
-                              ]
-                            },
-                            {
-                              operator:"!=",
-                              children: [
-                                {
-                                  operator:"objectProperties",
-                                  children: [
-                                    {
-                                      value: { property:"thisResponse" }
-                                    }
-                                  ]
-                                },
-                                { value: "" }
-                              ]
-                            }
-                          ]
-                        }
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: ".+" }
+                        ]
                       }
+                      validationMessage: "Cannot be blank"
+                      parameters: { label: "Enter the company acount name" }
                     }
                   ]
                 }
-              },
-              { 
+              }
+              {
                 code: "S3"
                 title: "Section 3"
                 index: 2
@@ -995,23 +845,17 @@ const queries = [
                       title: "Intro Section 1 - Page 1/1"
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
-                      parameters: {
-                        title: "Company staff details"
-                      }
-                    },
+                      parameters: { title: "Company staff details" }
+                    }
                     {
                       code: "S3Q1"
                       index: 0
                       title: "Organisation Size"
                       elementTypePluginCode: "dropdownChoice"
                       category: QUESTION
-                      parameters: { 
+                      parameters: {
                         label: "What is the size of the organization"
-                        options: [
-                          "Small",
-                          "Medium",
-                          "Large"
-                        ]
+                        options: ["Small", "Medium", "Large"]
                       }
                       isRequired: false
                     }
@@ -1117,20 +961,18 @@ const queries = [
                       title: "First Name"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: {
-                        label: "First Name"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            { value: ".+" }
-                          ]
-                        }
-                        validationMessage: "First name must not be blank"
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: ".+" }
+                        ]
                       }
+                      validationMessage: "First name must not be blank"
+                      parameters: { label: "First Name" }
                     }
                     {
                       code: "Q2"
@@ -1146,23 +988,21 @@ const queries = [
                       title: "Username"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: {
-                        label: "Select a username"
-                        validation: {
-                          operator: "API"
-                          children: [
-                            { value: "http://localhost:8080/check-unique" }
-                            { value: ["type", "value"] }
-                            { value: "username" }
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            { value: "unique" }
-                          ]
-                        }
-                        validationMessage: "Username must be unique"
+                      validation: {
+                        operator: "API"
+                        children: [
+                          { value: "http://localhost:8080/check-unique" }
+                          { value: ["type", "value"] }
+                          { value: "username" }
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: "unique" }
+                        ]
                       }
+                      validationMessage: "Username must be unique"
+                      parameters: { label: "Select a username" }
                     }
                     {
                       code: "Q4"
@@ -1170,22 +1010,20 @@ const queries = [
                       title: "Email"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: {
-                        label: "Email"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            {
-                              value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
-                            }
-                          ]
-                        }
-                        validationMessage: "Not a valid email address"
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          {
+                            value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
+                          }
+                        ]
                       }
+                      validationMessage: "Not a valid email address"
+                      parameters: { label: "Email" }
                     }
                     {
                       code: "Q5"
@@ -1193,23 +1031,23 @@ const queries = [
                       title: "Password"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: "^[\\\\S]{8,}$" }
+                        ]
+                      }
+                      validationMessage: "Password must be at least 8 characters"
+                      # Validation:Currently just checks 8 chars, needs more complexity
                       parameters: {
                         label: "Password"
                         maskedInput: true
                         placeholder: "Password must be at least 8 chars long"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            { value: "^[\\\\S]{8,}$" }
-                          ]
-                        }
-                        validationMessage: "Password must be at least 8 characters"
                       }
-                      # Validation:Currently just checks 8 chars, needs more complexity
                     }
                     # TO-DO: Add Date of birth question once we have DatePicker element type
                   ]
@@ -1356,22 +1194,20 @@ const queries = [
                       title: "Email"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
-                      parameters: {
-                        label: "Email"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            {
-                              value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
-                            }
-                          ]
-                        }
-                        validationMessage: "Not a valid email address"
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          {
+                            value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
+                          }
+                        ]
                       }
+                      validationMessage: "Not a valid email address"
+                      parameters: { label: "Email" }
                     }
                     {
                       code: "PB1"
@@ -1387,20 +1223,18 @@ const queries = [
                       elementTypePluginCode: "shortText"
                       category: QUESTION
                       isRequired: false
-                      parameters: {
-                        label: "Age"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            { value: "^[0-9]+$" }
-                          ]
-                        }
-                        validationMessage: "Response must be a number"
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: "^[0-9]+$" }
+                        ]
                       }
+                      validationMessage: "Response must be a number"
+                      parameters: { label: "Age" }
                     }
                     {
                       code: "Q5"
@@ -1476,20 +1310,20 @@ const queries = [
                       title: "Packet Size"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      validation: {
+                        operator: "REGEX"
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: [{ value: { property: "thisResponse" } }]
+                          }
+                          { value: "^[0-9]+$" }
+                        ]
+                      }
+                      validationMessage: "Must be a number"
                       parameters: {
                         label: "How many doses per packet?"
                         placeholder: "Whole number"
-                        validation: {
-                          operator: "REGEX"
-                          children: [
-                            {
-                              operator: "objectProperties"
-                              children: [{ value: { property: "thisResponse" } }]
-                            }
-                            { value: "^[0-9]+$" }
-                          ]
-                        }
-                        validationMessage: "Must be a number"
                       }
                     }
                     {
@@ -1542,17 +1376,17 @@ const queries = [
                 sequence: 2
                 parameterQueries: { message: "Application Submitted" }
               }
-            {
-              actionCode: "changeStatus"
-              trigger: ON_REVIEW_CREATE
-              parameterQueries: {
-                reviewId: {
-                  operator: "objectProperties"
-                  children: [{ value: { property: "record_id" } }]
+              {
+                actionCode: "changeStatus"
+                trigger: ON_REVIEW_CREATE
+                parameterQueries: {
+                  reviewId: {
+                    operator: "objectProperties"
+                    children: [{ value: { property: "record_id" } }]
+                  }
+                  newStatus: { value: "Draft" }
                 }
-                newStatus: { value: "Draft" }
               }
-            }
             ]
           }
         }

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1475,10 +1475,12 @@ export type ApplicationResponseTemplateElementIdFkeyTemplateElementCreateInput =
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -10922,10 +10924,12 @@ export type ReviewQuestionAssignmentTemplateElementIdFkeyTemplateElementCreateIn
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -12331,10 +12335,12 @@ export type TemplateElement = Node & {
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   /** Reads a single `TemplateSection` that is related to this `TemplateElement`. */
   section?: Maybe<TemplateSection>;
@@ -12416,14 +12422,18 @@ export type TemplateElementCondition = {
   title?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `category` field. */
   category?: Maybe<TemplateElementCategory>;
-  /** Checks for equality with the object’s `visibilityCondition` field. */
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `elementTypePluginCode` field. */
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `visibilityCondition` field. */
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `isRequired` field. */
   isRequired?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `isEditable` field. */
   isEditable?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `validation` field. */
+  validation?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `validationMessage` field. */
+  validationMessage?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `parameters` field. */
   parameters?: Maybe<Scalars['JSON']>;
 };
@@ -12442,14 +12452,18 @@ export type TemplateElementFilter = {
   title?: Maybe<StringFilter>;
   /** Filter by the object’s `category` field. */
   category?: Maybe<TemplateElementCategoryFilter>;
-  /** Filter by the object’s `visibilityCondition` field. */
-  visibilityCondition?: Maybe<JsonFilter>;
   /** Filter by the object’s `elementTypePluginCode` field. */
   elementTypePluginCode?: Maybe<StringFilter>;
+  /** Filter by the object’s `visibilityCondition` field. */
+  visibilityCondition?: Maybe<JsonFilter>;
   /** Filter by the object’s `isRequired` field. */
   isRequired?: Maybe<JsonFilter>;
   /** Filter by the object’s `isEditable` field. */
   isEditable?: Maybe<JsonFilter>;
+  /** Filter by the object’s `validation` field. */
+  validation?: Maybe<JsonFilter>;
+  /** Filter by the object’s `validationMessage` field. */
+  validationMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `parameters` field. */
   parameters?: Maybe<JsonFilter>;
   /** Filter by the object’s `applicationResponses` relation. */
@@ -12480,10 +12494,12 @@ export type TemplateElementInput = {
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -12555,10 +12571,12 @@ export type TemplateElementPatch = {
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -12623,10 +12641,12 @@ export type TemplateElementSectionIdFkeyTemplateElementCreateInput = {
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -12670,14 +12690,18 @@ export enum TemplateElementsOrderBy {
   TitleDesc = 'TITLE_DESC',
   CategoryAsc = 'CATEGORY_ASC',
   CategoryDesc = 'CATEGORY_DESC',
-  VisibilityConditionAsc = 'VISIBILITY_CONDITION_ASC',
-  VisibilityConditionDesc = 'VISIBILITY_CONDITION_DESC',
   ElementTypePluginCodeAsc = 'ELEMENT_TYPE_PLUGIN_CODE_ASC',
   ElementTypePluginCodeDesc = 'ELEMENT_TYPE_PLUGIN_CODE_DESC',
+  VisibilityConditionAsc = 'VISIBILITY_CONDITION_ASC',
+  VisibilityConditionDesc = 'VISIBILITY_CONDITION_DESC',
   IsRequiredAsc = 'IS_REQUIRED_ASC',
   IsRequiredDesc = 'IS_REQUIRED_DESC',
   IsEditableAsc = 'IS_EDITABLE_ASC',
   IsEditableDesc = 'IS_EDITABLE_DESC',
+  ValidationAsc = 'VALIDATION_ASC',
+  ValidationDesc = 'VALIDATION_DESC',
+  ValidationMessageAsc = 'VALIDATION_MESSAGE_ASC',
+  ValidationMessageDesc = 'VALIDATION_MESSAGE_DESC',
   ParametersAsc = 'PARAMETERS_ASC',
   ParametersDesc = 'PARAMETERS_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -16193,10 +16217,12 @@ export type UpdateTemplateElementOnApplicationResponseForApplicationResponseTemp
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -16211,10 +16237,12 @@ export type UpdateTemplateElementOnReviewQuestionAssignmentForReviewQuestionAssi
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -16228,10 +16256,12 @@ export type UpdateTemplateElementOnTemplateElementForTemplateElementSectionIdFke
   index?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   category?: Maybe<TemplateElementCategory>;
-  visibilityCondition?: Maybe<Scalars['JSON']>;
   elementTypePluginCode?: Maybe<Scalars['String']>;
+  visibilityCondition?: Maybe<Scalars['JSON']>;
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
+  validation?: Maybe<Scalars['JSON']>;
+  validationMessage?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
   applicationResponsesUsingId?: Maybe<ApplicationResponseTemplateElementIdFkeyInverseInput>;
@@ -21563,10 +21593,12 @@ export type TemplateElementResolvers<ContextType = any, ParentType extends Resol
   index?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   category?: Resolver<Maybe<ResolversTypes['TemplateElementCategory']>, ParentType, ContextType>;
-  visibilityCondition?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   elementTypePluginCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  visibilityCondition?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   isRequired?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   isEditable?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  validation?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  validationMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   parameters?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   section?: Resolver<Maybe<ResolversTypes['TemplateSection']>, ParentType, ContextType>;
   applicationResponses?: Resolver<ResolversTypes['ApplicationResponsesConnection'], ParentType, ContextType, RequireFields<TemplateElementApplicationResponsesArgs, 'orderBy'>>;


### PR DESCRIPTION
Back-end counterpart to [front-end issue #194/PR #215](https://github.com/openmsupply/application-manager-web-app/pull/215).

- Moves `validation` and `validationMessage` back to their own fields in `templateElement` instead of being parameters
- Update templates accordingly (`insertData.js`)