### PR TITLE
#154 Evaluator named objects and CONCAT bug fix

### DIFF
--- a/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
+++ b/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
@@ -50,7 +50,7 @@ function App() {
   const [objectsInput, setObjectsInput] = useState(
     localStorage.getItem('objectText') || `{firstName: "Carl", lastName: "Smith"}`
   )
-  const [objectArray, setObjectArray] = useState()
+  const [objects, setObjects] = useState()
   const [isObjectsValid, setIsObjectsValid] = useState(true)
   const [strictJSONInput, setStrictJSONInput] = useState(false)
   const [strictJSONObjInput, setStrictJSONObjInput] = useState(false)
@@ -74,7 +74,7 @@ function App() {
       cleanInput = { value: '< Invalid input >' }
     }
     evaluate(cleanInput, {
-      objects: objectArray,
+      objects: objects,
       pgConnection: pgInterface,
       graphQLConnection: { fetch: fetchNative, endpoint: graphQLendpoint },
       APIfetch: fetchNative,
@@ -89,7 +89,7 @@ function App() {
         setResultType('error')
       })
     localStorage.setItem('inputText', input)
-  }, [input, objectsInput, objectArray, evaluatorSelection])
+  }, [input, objectsInput, objects, evaluatorSelection])
 
   // Try and turn object(s) input string into object array
   useEffect(() => {
@@ -97,12 +97,12 @@ function App() {
     try {
       cleanObjectInput = looseJSON(objectsInput)
       if (!Array.isArray(cleanObjectInput)) {
-        cleanObjectInput = looseJSON(`[${objectsInput}]`)
+        cleanObjectInput = looseJSON(`${objectsInput}`)
       }
-      setObjectArray(cleanObjectInput)
+      setObjects(cleanObjectInput)
       setIsObjectsValid(true)
     } catch {
-      setObjectArray([])
+      setObjects({})
       setIsObjectsValid(false)
     } finally {
       localStorage.setItem('objectText', objectsInput)
@@ -168,7 +168,7 @@ function App() {
   }
 
   const prettifyObjects = () => {
-    let objectsInputArrayStr = encloseStringInBrackets(objectsInput)
+    let objectsInputArrayStr = objectsInput
     const pretty = JSONstringify(objectsInputArrayStr, false, strictJSONObjInput)
     if (pretty) setObjectsInput(pretty)
     else alert('Invalid input')
@@ -178,13 +178,6 @@ function App() {
     const compact = JSONstringify(objectsInput, true, strictJSONObjInput)
     if (compact) setObjectsInput(compact)
     else alert('Invalid input')
-  }
-
-  const encloseStringInBrackets = (string) => {
-    let outputString = string[0] !== '[' ? '[' + string : string
-    outputString =
-      outputString.substring(outputString.length - 1) !== ']' ? outputString + ']' : outputString
-    return outputString
   }
 
   return (

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -251,7 +251,7 @@ test('Testing Regex - Email validation', () => {
 // Return User or Form values
 
 test('Test returning single user property', () => {
-  return evaluateExpression(testData.singleUserProperty, { objects: [testData.user] }).then(
+  return evaluateExpression(testData.singleUserProperty, { objects: { user: testData.user } }).then(
     (result: any) => {
       expect(result).toBe('Carl')
     }
@@ -259,8 +259,8 @@ test('Test returning single user property', () => {
 })
 
 test('Test returning single application property, depth 2, no object index', () => {
-  return evaluateExpression(testData.singleApplicationProperty_noIndex_depth2, {
-    objects: [testData.application],
+  return evaluateExpression(testData.singleApplicationProperty_depth2, {
+    objects: { application: testData.application },
   }).then((result: any) => {
     expect(result).toBe('Enter your name')
   })
@@ -435,7 +435,7 @@ test('Test GraphQL -- Get list of templates -- no return node specifed', () => {
 
 test('Test GraphQL -- count Sections on current Application', () => {
   return evaluateExpression(testData.GraphQL_CountApplicationSections, {
-    objects: [testData.application],
+    objects: { application: testData.application },
     graphQLConnection: {
       fetch: fetch,
       endpoint: graphQLendpoint,
@@ -450,16 +450,16 @@ test('Test GraphQL -- count Sections on current Application', () => {
 // More complex combinations
 
 test('Test concatenate user First and Last names', () => {
-  return evaluateExpression(testData.concatFirstAndLastNames, { objects: [testData.user] }).then(
-    (result: any) => {
-      expect(result).toBe('Carl Smith')
-    }
-  )
+  return evaluateExpression(testData.concatFirstAndLastNames, {
+    objects: { user: testData.user },
+  }).then((result: any) => {
+    expect(result).toBe('Carl Smith')
+  })
 })
 
 test('Test Validation: Company name is unique', () => {
   return evaluateExpression(testData.complexValidation, {
-    objects: [testData.form2],
+    objects: { form2: testData.form2 },
     graphQLConnection: {
       fetch: fetch,
       endpoint: graphQLendpoint,
@@ -471,7 +471,7 @@ test('Test Validation: Company name is unique', () => {
 
 test('Test email validation -- email is unique and is valid email', () => {
   return evaluateExpression(testData.emailValidation, {
-    objects: [testData.form],
+    objects: { form: testData.form },
     APIfetch: fetch,
   }).then((result: any) => {
     expect(result).toBe(true)
@@ -480,7 +480,7 @@ test('Test email validation -- email is unique and is valid email', () => {
 
 test('Test visibility condition -- Answer to Q1 is Drug Registration and user belongs to at least one organisation', () => {
   return evaluateExpression(testData.complex1, {
-    objects: [testData.form, testData.user],
+    objects: { form: testData.form, user: testData.user },
     pgConnection: pgConnect,
   }).then((result: any) => {
     expect(result).toBe(false)

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -156,6 +156,12 @@ test('Testing String concatenation with type undefined', () => {
   })
 })
 
+test('Testing String concatenation output as Array', () => {
+  return evaluateExpression(testData.CONCAT_strings_output_as_array).then((result: any) => {
+    expect(result).toEqual(['One', 'Two', 'Three'])
+  })
+})
+
 // Equal (=) operator
 
 test('Testing Equality (numbers)', () => {

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -49,7 +49,7 @@ export default async function evaluateExpression(
         if (query.type === 'array') {
           return childrenResolved.reduce((acc: any, child: any) => {
             return acc.concat(child) // .flat(1) doesn't work for some reason
-          })
+          }, [])
         } else if (query.type === 'string' || !query.type) {
           return childrenResolved.join('')
         }

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -81,9 +81,8 @@ export default async function evaluateExpression(
         if (Object.entries(params).length === 0)
           return 'No parameters received for objectProperties node'
         try {
-          const objectIndex = childrenResolved[0].objectIndex ? childrenResolved[0].objectIndex : 0
-          const inputObject = params && params.objects ? params.objects[objectIndex] : {}
-          const property = childrenResolved[0].property
+          const inputObject = params?.objects ? params.objects : {}
+          const property = childrenResolved[0]
           return extractProperty(inputObject, property)
         } catch {
           throw new Error("Can't resolve object")

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -283,6 +283,18 @@ testData.CONCAT_4_Unspecified = {
   ],
 }
 
+testData.CONCAT_strings_output_as_array = {
+  operator: 'CONCAT',
+  type: 'array',
+  children: [
+    {
+      value: 'One',
+    },
+    'Two',
+    'Three',
+  ],
+}
+
 // Equal
 
 testData.EQUAL_Numbers = {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -507,20 +507,12 @@ testData.application = {
 
 testData.singleUserProperty = {
   operator: 'objectProperties',
-  children: [
-    {
-      value: { objectIndex: 0, property: 'firstName' },
-    },
-  ],
+  children: [{ value: 'user.firstName' }],
 }
 
-testData.singleApplicationProperty_noIndex_depth2 = {
+testData.singleApplicationProperty_depth2 = {
   operator: 'objectProperties',
-  children: [
-    {
-      value: { property: 'questions.q2' },
-    },
-  ],
+  children: ['application.questions.q2'],
 }
 
 // API operator
@@ -718,7 +710,7 @@ testData.GraphQL_CountApplicationSections = {
     { value: ['appId'] },
     {
       operator: 'objectProperties',
-      children: [{ value: { property: 'id' } }],
+      children: ['application.id'],
     },
     { value: 'application.applicationSections.totalCount' },
   ],
@@ -732,14 +724,14 @@ testData.concatFirstAndLastNames = {
   children: [
     {
       operator: 'objectProperties',
-      children: [{ value: { property: 'firstName' } }],
+      children: ['user.firstName'],
     },
     {
       value: ' ',
     },
     {
       operator: 'objectProperties',
-      children: [{ value: { property: 'lastName' } }],
+      children: ['user.lastName'],
     },
   ],
 }
@@ -752,7 +744,7 @@ testData.emailValidation = {
       children: [
         {
           operator: 'objectProperties',
-          children: [{ value: { property: 'q3' } }],
+          children: [{ value: 'form.q3' }],
         },
         {
           value: '^[A-Za-z0-9.]+@[A-Za-z0-9]+\\.[A-Za-z0-9.]+$',
@@ -771,7 +763,7 @@ testData.emailValidation = {
         { value: 'email' },
         {
           operator: 'objectProperties',
-          children: [{ value: { property: 'q3' } }],
+          children: ['form.q3'],
         },
         { value: 'unique' },
       ],
@@ -787,11 +779,7 @@ testData.complex1 = {
       children: [
         {
           operator: 'objectProperties',
-          children: [
-            {
-              value: { objectIndex: 0, property: 'q1' },
-            },
-          ],
+          children: [{ value: 'form.q1' }],
         },
         {
           value: 'Drug Registration',
@@ -808,7 +796,7 @@ testData.complex1 = {
             { value: 'SELECT COUNT(*) FROM user_organisation WHERE user_id = $1' },
             {
               operator: 'objectProperties',
-              children: [{ value: { objectIndex: 1, property: 'id' } }],
+              children: ['user.id'],
             },
           ],
         },
@@ -930,7 +918,7 @@ testData.complexValidation = {
         { value: ['orgName'] },
         {
           operator: 'objectProperties',
-          children: [{ value: { property: 'q2' } }],
+          children: ['form2.q2'],
         },
         { value: 'organisations.totalCount' },
       ],

--- a/src/modules/expression-evaluator/src/types.ts
+++ b/src/modules/expression-evaluator/src/types.ts
@@ -19,7 +19,7 @@ export interface IGraphQLConnection {
 }
 
 export interface IParameters {
-  objects?: object[]
+  objects?: BasicObject
   pgConnection?: IConnection
   graphQLConnection?: IGraphQLConnection
   APIfetch?: Function


### PR DESCRIPTION
Addresses #154 and #145. Was having a quick look last night and both turned out to be super-simple tweaks. Re-factoring the tests, docs and GUI app took 90% of the work!

Once this has been merged I'll re-publish the a new version of the evaluator package and go through and update all the templates and code with the new syntax (#159) -- it's only a very small change, but it's much better. Thanks for the suggestion @andreievg .

So instead of passing in an array of object which need to be referred to by index, you just pass them nested in a single object (e.g. `objects: { user, responses: allResponses } `, and then prefix the property you're fetching with the name of the object (e.g. `responses.Q1.text`). (See docs and tests for more clarity)

- The CONCAT bug (#145) was resolved by just specifying an empty array as the initial value for the accumulator in the `.reduce` method.

- I also wrote documentation for a suggested new "stringSubstitution" operator (#158) so we can assess it. Think it could be useful for dynamic titles, messages, etc. (easier than complex CONCATs)