### PR TITLE
#182F Add start and submission message to templates

### DIFF
--- a/database/buildSchema/07_template.sql
+++ b/database/buildSchema/07_template.sql
@@ -5,8 +5,11 @@ CREATE TYPE public.template_status AS ENUM ('Draft', 'Available', 'Disabled');
 CREATE TABLE public.template (
     id serial primary key,
     name varchar,
-	code varchar NOT NULL,
-is_linear boolean DEFAULT true,
+    code varchar NOT NULL,
+    is_linear boolean DEFAULT true,
+    start_title varchar,
+    start_message varchar,
     status public.template_status,
-    version_timestamp timestamptz   
+    submission_message varchar DEFAULT 'Thank you! Your application has been submitted.',
+    version_timestamp timestamptz
 );

--- a/database/buildSchema/07_template.sql
+++ b/database/buildSchema/07_template.sql
@@ -7,9 +7,8 @@ CREATE TABLE public.template (
     name varchar,
     code varchar NOT NULL,
     is_linear boolean DEFAULT true,
-    start_title varchar,
-    start_message varchar,
+    start_message jsonb,
     status public.template_status,
-    submission_message varchar DEFAULT 'Thank you! Your application has been submitted.',
+    submission_message jsonb DEFAULT '{"value": "Thank you! Your application has been submitted."}'::jsonb,
     version_timestamp timestamptz
 );

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -739,9 +739,7 @@ const queries = [
                       title: "Intro Section 2 - Page 1/2"
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
-                      parameters: {
-                        title: "Company location"
-                      }
+                      parameters: { title: "Company location" }
                       visibilityCondition: {
                         operator: "="
                         children: [
@@ -879,9 +877,7 @@ const queries = [
                       title: "Intro Section 1 - Page 1/1"
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
-                      parameters: { 
-                        title: "Company staff details"
-                      }
+                      parameters: { title: "Company staff details" }
                     }
                     {
                       code: "S3Q1"

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -6,9 +6,7 @@ const graphQLendpoint = config.graphQLendpoint
 
 const queries = [
   // Template A -- Test - General Registration (Feature showcase)
-  `
-
-  mutation {
+  `mutation {
     createTemplate(
       input: {
         template: {
@@ -16,7 +14,7 @@ const queries = [
           name: "Test -- General Registration"
           isLinear: false
           startMessage: """
-          ## This is the general registration for feature showcase\n- Proof of identity (Passport, Drivers license)\n- Proof of your medical certification\n- Drug ingredient list\n- Product images\n- Packging images\n
+          ## This is the general registration for feature showcase\n- Proof of identity (Passport, Drivers license)\n- Proof of your medical certification\n- Drug ingredient list\n- Product images\n- Packging images
           """
           status: AVAILABLE
           versionTimestamp: "NOW()"

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -6,19 +6,18 @@ const graphQLendpoint = config.graphQLendpoint
 
 const queries = [
   // Template A -- Test - General Registration (Feature showcase)
-  `mutation {
+  `
+
+  mutation {
     createTemplate(
       input: {
         template: {
           code: "TestRego"
           name: "Test -- General Registration"
           isLinear: false
-          startMessage: "## This is the general registration for feature showcase
-          - Proof of identity (Passport, Drivers license)
-          - Proof of your medical certification
-          - Drug ingredient list
-          - Product images
-          - Packging images"
+          startMessage: """
+          ## This is the general registration for feature showcase\n- Proof of identity (Passport, Drivers license)\n- Proof of your medical certification\n- Drug ingredient list\n- Product images\n- Packging images\n
+          """
           status: AVAILABLE
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
@@ -624,10 +623,9 @@ const queries = [
           name: "Company Registration"
           isLinear: false
           status: AVAILABLE
-          startMessage: "## You will need the following documents ready for upload
-            - Proof of Company name
-            - Proof of company address
-            - Bank account statement"
+          startMessage: """
+          ## You will need the following documents ready for upload\n- Proof of Company name\n- Proof of company address\n- Bank account statement
+          """
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
             create: [

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -609,8 +609,7 @@ const queries = [
         }
       }
     }
-  }
-  `,
+ }`,
   // Template B - Company Registration
   `mutation {
     createTemplate(

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -13,9 +13,7 @@ const queries = [
           code: "TestRego"
           name: "Test -- General Registration"
           isLinear: false
-          startMessage: """
-          ## This is the general registration for feature showcase\n- Proof of identity (Passport, Drivers license)\n- Proof of your medical certification\n- Drug ingredient list\n- Product images\n- Packging images
-          """
+          startMessage: "## This is the general registration for feature showcase\\n- Proof of identity (Passport, Drivers license)\\n- Proof of your medical certification\\n- Drug ingredient list\\n- Product images\\n- Packging images"
           status: AVAILABLE
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
@@ -611,7 +609,8 @@ const queries = [
         }
       }
     }
-  }`,
+  }
+  `,
   // Template B - Company Registration
   `mutation {
     createTemplate(
@@ -621,9 +620,7 @@ const queries = [
           name: "Company Registration"
           isLinear: false
           status: AVAILABLE
-          startMessage: """
-          ## You will need the following documents ready for upload\n- Proof of Company name\n- Proof of company address\n- Bank account statement
-          """
+          startMessage: "## You will need the following documents ready for upload\\n- Proof of Company name\\n- Proof of company address\\n- Bank account statement"
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
             create: [

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -13,13 +13,12 @@ const queries = [
           code: "TestRego"
           name: "Test -- General Registration"
           isLinear: false
-          startTitle: "This is the general registration for feature showcase"
-          startMessage: 
-            """Proof of identity (Passport, Drivers license)\n
-            Proof of your medical certification\n
-            Drug ingredient list\n
-            Product images\n
-            Packging images\n"""
+          startMessage: "## This is the general registration for feature showcase
+          - Proof of identity (Passport, Drivers license)
+          - Proof of your medical certification
+          - Drug ingredient list
+          - Product images
+          - Packging images"
           status: AVAILABLE
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
@@ -625,11 +624,10 @@ const queries = [
           name: "Company Registration"
           isLinear: false
           status: AVAILABLE
-          startTitle: "you will need the following documents ready for upload"
-          startMessage: 
-            """Proof of Company name\n
-            Proof of company address\n
-            Bank account statement\n"""
+          startMessage: "## You will need the following documents ready for upload
+            - Proof of Company name
+            - Proof of company address
+            - Bank account statement"
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
             create: [

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -13,6 +13,13 @@ const queries = [
           code: "TestRego"
           name: "Test -- General Registration"
           isLinear: false
+          startTitle: "This is the general registration for feature showcase"
+          startMessage: 
+            """Proof of identity (Passport, Drivers license)\n
+            Proof of your medical certification\n
+            Drug ingredient list\n
+            Product images\n
+            Packging images\n"""
           status: AVAILABLE
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
@@ -618,6 +625,11 @@ const queries = [
           name: "Company Registration"
           isLinear: false
           status: AVAILABLE
+          startTitle: "you will need the following documents ready for upload"
+          startMessage: 
+            """Proof of Company name\n
+            Proof of company address\n
+            Bank account statement\n"""
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
             create: [
@@ -729,7 +741,9 @@ const queries = [
                       title: "Intro Section 2 - Page 1/2"
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
-                      parameters: { label: "Company location" }
+                      parameters: {
+                        title: "Company location"
+                      }
                       visibilityCondition: {
                         operator: "="
                         children: [
@@ -867,7 +881,9 @@ const queries = [
                       title: "Intro Section 1 - Page 1/1"
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
-                      parameters: { title: "Company staff details" }
+                      parameters: { 
+                        title: "Company staff details"
+                      }
                     }
                     {
                       code: "S3Q1"
@@ -956,6 +972,7 @@ const queries = [
         template: {
           code: "UserRegistration"
           name: "User Registration"
+          submissionMessage: "Your registration has been completed. Please follow the link sent via email to confirm"
           status: AVAILABLE
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {

--- a/documentation/Database-Schema-Template.md
+++ b/documentation/Database-Schema-Template.md
@@ -20,9 +20,9 @@ The `name` is what users of the system will see as the "Application Type" -- e.g
 
 The `is_linear` is used to define the applications flow. If linear it is require each page to be complete before allowing the user to move to the next one. If not the user can go to any page, and only when trying to go to the summary page would be required that all required fields have been completed.
 
-The `start_title` and `start_message` are optional and would define if the application should have a start page or not (when both are Null). In case it is defined the start page is showed when the user clicks on the application in the list or when the user wants to start one.
+The `start_message` is an optional JSON field written using markdown format. If this message is defined then the application show a start page otherwise not. In case it is defined the start page is showed when the user clicks on the application in the list or when the user wants to start a new one.
 
-The `submission_message` has a default general message set, that will always be displayed after the application has been submitted, a specific submission message can be defined per template.
+The `submission_message` is also option JSON field written using markdown format. It has a default general message set that will always be displayed after the application has been submitted, but a specific submission message can be defined per template.
 
 **To be considered: Should we check if no applications are associated with an existing template and just add changes to the current version instead?**
 

--- a/documentation/Database-Schema-Template.md
+++ b/documentation/Database-Schema-Template.md
@@ -12,11 +12,17 @@ The sections and questions required in each stage of an application is defined i
 
 Representation of the application template. All nested elements are accessible via joined tables and can be created or queried in the same call using the GraphQL engine.
 
-Whenever a template is modified, the new version is saved as a new template record with a new `version_timestamp`. Different versions of the same base template are connected with the same `code`. The `status` field is used to indicate which version is the current active one.
+Whenever a template is modified, the new version is saved as a new template record with a new `version_timestamp`. Different versions of the same base template are connected with the same `code`. The `status` field is used to indicate which version is the current available one.
+
+The `status` can be `'Draft'`, `'Available'` or `'Disabled'`. The version currently active in the system is the one (and only one) marked `'Available'`.
 
 The `name` is what users of the system will see as the "Application Type" -- e.g. "Drug Registration".
 
-The `status` can be `'Draft'`, `'Available'` or `'Disabled'`. The version currently active in the system is the one (and only one) marked `'Available'`.
+The `is_linear` is used to define the applications flow. If linear it is require each page to be complete before allowing the user to move to the next one. If not the user can go to any page, and only when trying to go to the summary page would be required that all required fields have been completed.
+
+The `start_title` and `start_message` are optional and would define if the application should have a start page or not (when both are Null). In case it is defined the start page is showed when the user clicks on the application in the list or when the user wants to start one.
+
+The `submission_message` has a default general message set, that will always be displayed after the application has been submitted, a specific submission message can be defined per template.
 
 **To be considered: Should we check if no applications are associated with an existing template and just add changes to the current version instead?**
 

--- a/documentation/Database-Schema-Template.md
+++ b/documentation/Database-Schema-Template.md
@@ -20,9 +20,11 @@ The `name` is what users of the system will see as the "Application Type" -- e.g
 
 The `is_linear` is used to define the applications flow. If linear it is require each page to be complete before allowing the user to move to the next one. If not the user can go to any page, and only when trying to go to the summary page would be required that all required fields have been completed.
 
-The `start_message` is an optional JSON field written using markdown format. If this message is defined then the application show a start page otherwise not. In case it is defined the start page is showed when the user clicks on the application in the list or when the user wants to start a new one.
+The `start_message`, optional JSON field **\***. When is defined the application shows a start page otherwise not. In case it is defined the start page is showed when the user clicks on the application in the list or when the user wants to start a new one.
 
-The `submission_message` is also option JSON field written using markdown format. It has a default general message set that will always be displayed after the application has been submitted, but a specific submission message can be defined per template.
+The `submission_message`, optional JSON field **\***. It has a default general message set that will always be displayed after the application has been submitted, but a specific submission message can be defined per template.
+
+**\*** The `JSON field` is an evaluator expression that returns a markdown string. (Query evaluation not yet implemented)
 
 **To be considered: Should we check if no applications are associated with an existing template and just add changes to the current version instead?**
 

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -493,7 +493,10 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -2671,7 +2674,10 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -12021,7 +12027,10 @@ export type Template = Node & {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   /** Reads and enables pagination through a set of `TemplateStage`. */
   templateStages: TemplateStagesConnection;
@@ -12332,7 +12341,10 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -12355,8 +12367,14 @@ export type TemplateCondition = {
   code?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `isLinear` field. */
   isLinear?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `startTitle` field. */
+  startTitle?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `startMessage` field. */
+  startMessage?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `status` field. */
   status?: Maybe<TemplateStatus>;
+  /** Checks for equality with the object’s `submissionMessage` field. */
+  submissionMessage?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<Scalars['Datetime']>;
 };
@@ -12784,8 +12802,14 @@ export type TemplateFilter = {
   code?: Maybe<StringFilter>;
   /** Filter by the object’s `isLinear` field. */
   isLinear?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `startTitle` field. */
+  startTitle?: Maybe<StringFilter>;
+  /** Filter by the object’s `startMessage` field. */
+  startMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<TemplateStatusFilter>;
+  /** Filter by the object’s `submissionMessage` field. */
+  submissionMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `templateStages` relation. */
@@ -12826,7 +12850,10 @@ export type TemplateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -12944,7 +12971,10 @@ export type TemplatePatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13243,7 +13273,10 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13638,7 +13671,10 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13720,8 +13756,14 @@ export enum TemplatesOrderBy {
   CodeDesc = 'CODE_DESC',
   IsLinearAsc = 'IS_LINEAR_ASC',
   IsLinearDesc = 'IS_LINEAR_DESC',
+  StartTitleAsc = 'START_TITLE_ASC',
+  StartTitleDesc = 'START_TITLE_DESC',
+  StartMessageAsc = 'START_MESSAGE_ASC',
+  StartMessageDesc = 'START_MESSAGE_DESC',
   StatusAsc = 'STATUS_ASC',
   StatusDesc = 'STATUS_DESC',
+  SubmissionMessageAsc = 'SUBMISSION_MESSAGE_ASC',
+  SubmissionMessageDesc = 'SUBMISSION_MESSAGE_DESC',
   VersionTimestampAsc = 'VERSION_TIMESTAMP_ASC',
   VersionTimestampDesc = 'VERSION_TIMESTAMP_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -13973,7 +14015,10 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16352,7 +16397,10 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16368,7 +16416,10 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16384,7 +16435,10 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16400,7 +16454,10 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16416,7 +16473,10 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16432,7 +16492,10 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -21593,7 +21656,10 @@ export type TemplateResolvers<ContextType = any, ParentType extends ResolversPar
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   isLinear?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  startTitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  startMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['TemplateStatus']>, ParentType, ContextType>;
+  submissionMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   versionTimestamp?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
   templateStages?: Resolver<ResolversTypes['TemplateStagesConnection'], ParentType, ContextType, RequireFields<TemplateTemplateStagesArgs, 'orderBy'>>;
   templateSections?: Resolver<ResolversTypes['TemplateSectionsConnection'], ParentType, ContextType, RequireFields<TemplateTemplateSectionsArgs, 'orderBy'>>;

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -493,10 +493,9 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -2674,10 +2673,9 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -12027,10 +12025,9 @@ export type Template = Node & {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   /** Reads and enables pagination through a set of `TemplateStage`. */
   templateStages: TemplateStagesConnection;
@@ -12341,10 +12338,9 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -12367,14 +12363,12 @@ export type TemplateCondition = {
   code?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `isLinear` field. */
   isLinear?: Maybe<Scalars['Boolean']>;
-  /** Checks for equality with the object’s `startTitle` field. */
-  startTitle?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `startMessage` field. */
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `status` field. */
   status?: Maybe<TemplateStatus>;
   /** Checks for equality with the object’s `submissionMessage` field. */
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<Scalars['Datetime']>;
 };
@@ -12802,14 +12796,12 @@ export type TemplateFilter = {
   code?: Maybe<StringFilter>;
   /** Filter by the object’s `isLinear` field. */
   isLinear?: Maybe<BooleanFilter>;
-  /** Filter by the object’s `startTitle` field. */
-  startTitle?: Maybe<StringFilter>;
   /** Filter by the object’s `startMessage` field. */
-  startMessage?: Maybe<StringFilter>;
+  startMessage?: Maybe<JsonFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<TemplateStatusFilter>;
   /** Filter by the object’s `submissionMessage` field. */
-  submissionMessage?: Maybe<StringFilter>;
+  submissionMessage?: Maybe<JsonFilter>;
   /** Filter by the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `templateStages` relation. */
@@ -12850,10 +12842,9 @@ export type TemplateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -12971,10 +12962,9 @@ export type TemplatePatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13273,10 +13263,9 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13671,10 +13660,9 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13756,8 +13744,6 @@ export enum TemplatesOrderBy {
   CodeDesc = 'CODE_DESC',
   IsLinearAsc = 'IS_LINEAR_ASC',
   IsLinearDesc = 'IS_LINEAR_DESC',
-  StartTitleAsc = 'START_TITLE_ASC',
-  StartTitleDesc = 'START_TITLE_DESC',
   StartMessageAsc = 'START_MESSAGE_ASC',
   StartMessageDesc = 'START_MESSAGE_DESC',
   StatusAsc = 'STATUS_ASC',
@@ -14015,10 +14001,9 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16397,10 +16382,9 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16416,10 +16400,9 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16435,10 +16418,9 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16454,10 +16436,9 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16473,10 +16454,9 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -16492,10 +16472,9 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -21656,10 +21635,9 @@ export type TemplateResolvers<ContextType = any, ParentType extends ResolversPar
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   isLinear?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  startTitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  startMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  startMessage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['TemplateStatus']>, ParentType, ContextType>;
-  submissionMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  submissionMessage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   versionTimestamp?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
   templateStages?: Resolver<ResolversTypes['TemplateStagesConnection'], ParentType, ContextType, RequireFields<TemplateTemplateStagesArgs, 'orderBy'>>;
   templateSections?: Resolver<ResolversTypes['TemplateSectionsConnection'], ParentType, ContextType, RequireFields<TemplateTemplateSectionsArgs, 'orderBy'>>;


### PR DESCRIPTION
To be used as back-end for Front-end issue [182](https://github.com/openmsupply/application-manager-web-app/issues/182).

## Changes
- Add to table **template** new fields: `start_title`, `start_message` and `submission_message`.
- The submission message has a DEFAULT value, to be used if none is provided.
- Fix a minor problem with section title.