### PR TITLE
#158 Evaluator -- string substitution operator

### DIFF
--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -157,14 +157,11 @@ application = {
 
 ## stringSubstitution
 
-_(Not yet implemented)_
-
-Replaces placeholder parameters (`$1`, `$2`, etc) in strings with values supplied during evaluation.
+Replaces placeholder parameters (`%1`, `%2`, etc) in strings with values supplied during evaluation.
 
 - Input:
 
-  - 1st child node returns a **string** containing a parameterized query (e.g.`"Hello %1, welcome to our application!"` )  
-    Parameters can be written in either percent (`%1, %2`) or dollar-sign (`$1, $2`) notation
+  - 1st child node returns a **string** containing a parameterized query (e.g.`"Hello %1, welcome to our application!"` )
   - 2nd...N nodes provide the replacement **strings** for the parameters in the first string.
 
   **Example**:

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -272,6 +272,71 @@ test('Test returning single application property, depth 2, no object index', () 
   })
 })
 
+// String substitution
+test('Simple string substitution', () => {
+  return evaluateExpression(testData.stringSubstitutionSingle).then((result: any) => {
+    expect(result).toBe('Hello, friend, welcome to our site.')
+  })
+})
+
+test('Simple string substitution - multiple replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionMultiple).then((result: any) => {
+    expect(result).toBe(
+      "There are 10 kinds of people in the world:\nthose who understand binary and those who don't"
+    )
+  })
+})
+
+test('String substitution - non-string replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionNonStringReplacements).then(
+    (result: any) => {
+      expect(result).toBe('We have 2 people listed: [Boba, Mando]')
+    }
+  )
+})
+
+test('String substitution - too many replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionTooManyReplacements).then((result: any) => {
+    expect(result).toBe('The price of milk is $2.39 per liter')
+  })
+})
+
+test('String substitution - too few replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionTooFewReplacements).then((result: any) => {
+    expect(result).toBe("The applicant's name is Carl Smith %3.")
+  })
+})
+
+test('String substitution - parameters not ordered', () => {
+  return evaluateExpression(testData.stringSubstitutionParametersNonOrdered).then((result: any) => {
+    expect(result).toBe('Two out of every 3 people are stupid')
+  })
+})
+
+test('String substitution - parameters not ordered and too few', () => {
+  return evaluateExpression(testData.stringSubstitutionParametersNonOrderedAndTooFew).then(
+    (result: any) => {
+      expect(result).toBe('Two out of every %3 people are stupid')
+    }
+  )
+})
+
+test('String substitution - ignore literals', () => {
+  return evaluateExpression(testData.stringSubstitutionIgnoreLiteral).then((result: any) => {
+    expect(result).toBe(
+      `We don't want %2 to be replaced but we do want this to be replaced, and we want there to be a single \ here.`
+    )
+  })
+})
+
+test('String substitution - parameters not sequential', () => {
+  return evaluateExpression(testData.stringSubstitutionParametersNotSequential).then(
+    (result: any) => {
+      expect(result).toBe(`It shouldn't matter if there are big gaps between parameter numbers`)
+    }
+  )
+})
+
 // API operator
 test('API: Check username is unique', () => {
   return evaluateExpression(testData.APIisUnique, {

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -273,69 +273,73 @@ test('Test returning single application property, depth 2, no object index', () 
 })
 
 // String substitution
+
 test('Simple string substitution', () => {
-  return evaluateExpression(testData.stringSubstitutionSingle).then((result: any) => {
-    expect(result).toBe('Hello, friend, welcome to our site.')
+  return evaluateExpression({
+    operator: 'stringSubstitution',
+    children: ['Hello, %1, welcome to our site.', 'friend'],
+  }).then((result: any) => {
+    expect(result).toEqual('Hello, friend, welcome to our site.')
   })
 })
 
-test('Simple string substitution - multiple replacements', () => {
-  return evaluateExpression(testData.stringSubstitutionMultiple).then((result: any) => {
-    expect(result).toBe(
-      "There are 10 kinds of people in the world:\nthose who understand binary and those who don't"
-    )
-  })
-})
+// test('Simple string substitution - multiple replacements', () => {
+//   return evaluateExpression(testData.stringSubstitutionMultiple).then((result: any) => {
+//     expect(result).toBe(
+//       "There are 10 kinds of people in the world:\nthose who understand binary and those who don't"
+//     )
+//   })
+// })
 
-test('String substitution - non-string replacements', () => {
-  return evaluateExpression(testData.stringSubstitutionNonStringReplacements).then(
-    (result: any) => {
-      expect(result).toBe('We have 2 people listed: [Boba, Mando]')
-    }
-  )
-})
+// test('String substitution - non-string replacements', () => {
+//   return evaluateExpression(testData.stringSubstitutionNonStringReplacements).then(
+//     (result: any) => {
+//       expect(result).toBe('We have 2 people listed: [Boba, Mando]')
+//     }
+//   )
+// })
 
-test('String substitution - too many replacements', () => {
-  return evaluateExpression(testData.stringSubstitutionTooManyReplacements).then((result: any) => {
-    expect(result).toBe('The price of milk is $2.39 per liter')
-  })
-})
+// test('String substitution - too many replacements', () => {
+//   return evaluateExpression(testData.stringSubstitutionTooManyReplacements).then((result: any) => {
+//     expect(result).toBe('The price of milk is $2.39 per liter')
+//   })
+// })
 
-test('String substitution - too few replacements', () => {
-  return evaluateExpression(testData.stringSubstitutionTooFewReplacements).then((result: any) => {
-    expect(result).toBe("The applicant's name is Carl Smith %3.")
-  })
-})
+// test('String substitution - too few replacements', () => {
+//   return evaluateExpression(testData.stringSubstitutionTooFewReplacements).then((result: any) => {
+//     expect(result).toBe("The applicant's name is Carl Smith %3.")
+//   })
+// })
 
-test('String substitution - parameters not ordered', () => {
-  return evaluateExpression(testData.stringSubstitutionParametersNonOrdered).then((result: any) => {
-    expect(result).toBe('Two out of every 3 people are stupid')
-  })
-})
+// test('String substitution - parameters not ordered', () => {
+//   return evaluateExpression(testData.stringSubstitutionParametersNonOrdered).then((result: any) => {
+//     expect(result).toBe('Two out of every 3 people are stupid')
+//   })
+// })
 
-test('String substitution - parameters not ordered and too few', () => {
-  return evaluateExpression(testData.stringSubstitutionParametersNonOrderedAndTooFew).then(
-    (result: any) => {
-      expect(result).toBe('Two out of every %3 people are stupid')
-    }
-  )
-})
+// test('String substitution - parameters not ordered and too few', () => {
+//   return evaluateExpression(testData.stringSubstitutionParametersNonOrderedAndTooFew).then(
+//     (result: any) => {
+//       expect(result).toBe('Two out of every %3 people are stupid')
+//     }
+//   )
+// })
 
-test('String substitution - ignore literals', () => {
-  return evaluateExpression(testData.stringSubstitutionIgnoreLiteral).then((result: any) => {
-    expect(result).toBe(
-      `We don't want %2 to be replaced but we do want this to be replaced, and we want there to be a single \ here.`
-    )
-  })
-})
+// test('String substitution - ignore literals', () => {
+//   return evaluateExpression(testData.stringSubstitutionIgnoreLiteral).then((result: any) => {
+//     expect(result).toBe(
+//       `We don't want %2 to be replaced but we do want this to be replaced, and we want there to be a single \ here.`
+//     )
+//   })
+// })
 
-test('String substitution - parameters not sequential', () => {
-  return evaluateExpression(testData.stringSubstitutionParametersNotSequential).then(
-    (result: any) => {
-      expect(result).toBe(`It shouldn't matter if there are big gaps between parameter numbers`)
-    }
-  )
-})
+// test('String substitution - parameters not sequential', () => {
+//   return evaluateExpression(testData.stringSubstitutionParametersNotSequential).then(
+//     (result: any) => {
+//       expect(result).toBe(`It shouldn't matter if there are big gaps between parameter numbers`)
+//     }
+//   )
+// })
 
 // API operator
 test('API: Check username is unique', () => {

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -317,17 +317,9 @@ test('String substitution - parameters not ordered', () => {
 test('String substitution - parameters not ordered and too few', () => {
   return evaluateExpression(testData.stringSubstitutionParametersNonOrderedAndTooFew).then(
     (result: any) => {
-      expect(result).toBe('Two out of every %3 people are stupid')
+      expect(result).toBe('Two out of every  people are stupid')
     }
   )
-})
-
-test('String substitution - ignore literals', () => {
-  return evaluateExpression(testData.stringSubstitutionIgnoreLiteral).then((result: any) => {
-    expect(result).toBe(
-      `We don't want %2 to be replaced but we do want this to be replaced, and we want there to be a single \ here.`
-    )
-  })
 })
 
 test('String substitution - parameters not sequential', () => {
@@ -336,6 +328,18 @@ test('String substitution - parameters not sequential', () => {
       expect(result).toBe(`It shouldn't matter if there are big gaps between parameter numbers`)
     }
   )
+})
+
+test('String substitution - no parameters', () => {
+  return evaluateExpression(testData.stringSubstitutionNoParameters).then((result: any) => {
+    expect(result).toBe('This sentence has no replacements.')
+  })
+})
+
+test('String substitution - no replacements supplied', () => {
+  return evaluateExpression(testData.stringSubstitutionNoReplacements).then((result: any) => {
+    expect(result).toBe('Your name is   but we have nothing to replace them with')
+  })
 })
 
 // API operator

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -275,71 +275,68 @@ test('Test returning single application property, depth 2, no object index', () 
 // String substitution
 
 test('Simple string substitution', () => {
-  return evaluateExpression({
-    operator: 'stringSubstitution',
-    children: ['Hello, %1, welcome to our site.', 'friend'],
-  }).then((result: any) => {
+  return evaluateExpression(testData.stringSubstitutionSingle).then((result: any) => {
     expect(result).toEqual('Hello, friend, welcome to our site.')
   })
 })
 
-// test('Simple string substitution - multiple replacements', () => {
-//   return evaluateExpression(testData.stringSubstitutionMultiple).then((result: any) => {
-//     expect(result).toBe(
-//       "There are 10 kinds of people in the world:\nthose who understand binary and those who don't"
-//     )
-//   })
-// })
+test('Simple string substitution - multiple replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionMultiple).then((result: any) => {
+    expect(result).toBe(
+      "There are 10 kinds of people in the world:\nthose who understand binary and those who don't"
+    )
+  })
+})
 
-// test('String substitution - non-string replacements', () => {
-//   return evaluateExpression(testData.stringSubstitutionNonStringReplacements).then(
-//     (result: any) => {
-//       expect(result).toBe('We have 2 people listed: [Boba, Mando]')
-//     }
-//   )
-// })
+test('String substitution - non-string replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionNonStringReplacements).then(
+    (result: any) => {
+      expect(result).toBe('We have 2 people listed: Boba,Mando')
+    }
+  )
+})
 
-// test('String substitution - too many replacements', () => {
-//   return evaluateExpression(testData.stringSubstitutionTooManyReplacements).then((result: any) => {
-//     expect(result).toBe('The price of milk is $2.39 per liter')
-//   })
-// })
+test('String substitution - too many replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionTooManyReplacements).then((result: any) => {
+    expect(result).toBe('The price of milk is $2.30 per liter')
+  })
+})
 
-// test('String substitution - too few replacements', () => {
-//   return evaluateExpression(testData.stringSubstitutionTooFewReplacements).then((result: any) => {
-//     expect(result).toBe("The applicant's name is Carl Smith %3.")
-//   })
-// })
+test('String substitution - too few replacements', () => {
+  return evaluateExpression(testData.stringSubstitutionTooFewReplacements).then((result: any) => {
+    expect(result).toBe("The applicant's name is Carl Smith .")
+  })
+})
 
-// test('String substitution - parameters not ordered', () => {
-//   return evaluateExpression(testData.stringSubstitutionParametersNonOrdered).then((result: any) => {
-//     expect(result).toBe('Two out of every 3 people are stupid')
-//   })
-// })
+test('String substitution - parameters not ordered', () => {
+  return evaluateExpression(testData.stringSubstitutionParametersNonOrdered).then((result: any) => {
+    expect(result).toBe('Two out of every 3 people are stupid')
+  })
+})
 
-// test('String substitution - parameters not ordered and too few', () => {
-//   return evaluateExpression(testData.stringSubstitutionParametersNonOrderedAndTooFew).then(
-//     (result: any) => {
-//       expect(result).toBe('Two out of every %3 people are stupid')
-//     }
-//   )
-// })
+test('String substitution - parameters not ordered and too few', () => {
+  return evaluateExpression(testData.stringSubstitutionParametersNonOrderedAndTooFew).then(
+    (result: any) => {
+      expect(result).toBe('Two out of every %3 people are stupid')
+    }
+  )
+})
 
-// test('String substitution - ignore literals', () => {
-//   return evaluateExpression(testData.stringSubstitutionIgnoreLiteral).then((result: any) => {
-//     expect(result).toBe(
-//       `We don't want %2 to be replaced but we do want this to be replaced, and we want there to be a single \ here.`
-//     )
-//   })
-// })
+test('String substitution - ignore literals', () => {
+  return evaluateExpression(testData.stringSubstitutionIgnoreLiteral).then((result: any) => {
+    expect(result).toBe(
+      `We don't want %2 to be replaced but we do want this to be replaced, and we want there to be a single \ here.`
+    )
+  })
+})
 
-// test('String substitution - parameters not sequential', () => {
-//   return evaluateExpression(testData.stringSubstitutionParametersNotSequential).then(
-//     (result: any) => {
-//       expect(result).toBe(`It shouldn't matter if there are big gaps between parameter numbers`)
-//     }
-//   )
-// })
+test('String substitution - parameters not sequential', () => {
+  return evaluateExpression(testData.stringSubstitutionParametersNotSequential).then(
+    (result: any) => {
+      expect(result).toBe(`It shouldn't matter if there are big gaps between parameter numbers`)
+    }
+  )
+})
 
 // API operator
 test('API: Check username is unique', () => {

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -291,7 +291,7 @@ test('Simple string substitution - multiple replacements', () => {
 test('String substitution - non-string replacements', () => {
   return evaluateExpression(testData.stringSubstitutionNonStringReplacements).then(
     (result: any) => {
-      expect(result).toBe('We have 2 people listed: Boba,Mando')
+      expect(result).toBe('We have 2 people listed with an average value of 4.53: Boba,Mando')
     }
   )
 })

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -89,20 +89,16 @@ export default async function evaluateExpression(
         }
 
       case 'stringSubstitution':
-        const origString = childrenResolved[0]
+        const origString: string = childrenResolved[0]
         const replacements = childrenResolved.slice(1)
-        const parameters = [...origString.matchAll(/(?<![\\])%([\d]+)/g)].sort(
-          (a, b) => Number(a[1]) - Number(b[1])
-        )
-        const zippedParametersReplacements = parameters.map((param, index) => [
-          param[0],
-          replacements[index],
-        ])
-
-        return zippedParametersReplacements.reduce(
-          (outputString, [param, replacement]) => outputString.replace(param, replacement),
-          origString
-        )
+        const regex = /(?<![\\])%([\d]+)/g
+        const parameters = origString.match(regex) || []
+        const orderedReplacements = parameters
+          .map((param, index) => [Number(param.slice(1)), replacements[index]])
+          .sort((a, b) => a[0] - b[0])
+          .map((pair) => (pair[1] ? pair[1] : ''))
+        let i = 0
+        return origString.replace(regex, () => orderedReplacements[i++])
 
       case 'API':
         let url, urlWithQuery, queryFields, queryValues: string[], returnProperty

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -91,16 +91,14 @@ export default async function evaluateExpression(
       case 'stringSubstitution':
         const origString: string = childrenResolved[0]
         const replacements = childrenResolved.slice(1)
-        const regex = /(?<![\\])%([\d]+)/g
+        const regex = /%([\d]+)/g // To-Do: handle escaping literal values
         const parameters = (origString.match(regex) || []).sort(
           (a, b) => Number(a.slice(1)) - Number(b.slice(1))
         )
         let i = 0
-        return parameters.reduce(
-          (outputString, param) =>
-            outputString.replace(param, replacements[i] ? replacements[i++] : ''),
-          origString
-        )
+        return parameters.reduce((outputString, param) => {
+          return outputString.replace(param, replacements[i] ? replacements[i++] : '')
+        }, origString)
 
       case 'API':
         let url, urlWithQuery, queryFields, queryValues: string[], returnProperty

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -89,7 +89,20 @@ export default async function evaluateExpression(
         }
 
       case 'stringSubstitution':
-        return 'Not implemented yet'
+        const origString = childrenResolved[0]
+        const replacements = childrenResolved.slice(1)
+        const parameters = [...origString.matchAll(/(?<![\\])%([\d]+)/g)].sort(
+          (a, b) => Number(a[1]) - Number(b[1])
+        )
+        const zippedParametersReplacements = parameters.map((param, index) => [
+          param[0],
+          replacements[index],
+        ])
+
+        return zippedParametersReplacements.reduce(
+          (outputString, [param, replacement]) => outputString.replace(param, replacement),
+          origString
+        )
 
       case 'API':
         let url, urlWithQuery, queryFields, queryValues: string[], returnProperty

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -92,13 +92,15 @@ export default async function evaluateExpression(
         const origString: string = childrenResolved[0]
         const replacements = childrenResolved.slice(1)
         const regex = /(?<![\\])%([\d]+)/g
-        const parameters = origString.match(regex) || []
-        const orderedReplacements = parameters
-          .map((param, index) => [Number(param.slice(1)), replacements[index]])
-          .sort((a, b) => a[0] - b[0])
-          .map((pair) => (pair[1] ? pair[1] : ''))
+        const parameters = (origString.match(regex) || []).sort(
+          (a, b) => Number(a.slice(1)) - Number(b.slice(1))
+        )
         let i = 0
-        return origString.replace(regex, () => orderedReplacements[i++])
+        return parameters.reduce(
+          (outputString, param) =>
+            outputString.replace(param, replacements[i] ? replacements[i++] : ''),
+          origString
+        )
 
       case 'API':
         let url, urlWithQuery, queryFields, queryValues: string[], returnProperty

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -88,6 +88,9 @@ export default async function evaluateExpression(
           throw new Error("Can't resolve object")
         }
 
+      case 'stringSubstitution':
+        return 'Not implemented yet'
+
       case 'API':
         let url, urlWithQuery, queryFields, queryValues: string[], returnProperty
         try {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -569,13 +569,6 @@ testData.stringSubstitutionParametersNonOrderedAndTooFew = {
   children: ['%2 out of every %3 people are %1', 'stupid', 'Two'],
 }
 
-testData.stringSubstitutionIgnoreLiteral = {
-  operator: 'stringSubstitution',
-  children: [
-    `We don't want \%2 to be replaced but we do want %1 to be replaced, and we want there to be a single \\ here.`,
-    'this',
-  ],
-}
 testData.stringSubstitutionParametersNotSequential = {
   operator: 'stringSubstitution',
   children: [
@@ -585,6 +578,16 @@ testData.stringSubstitutionParametersNotSequential = {
     'parameter',
     'numbers',
   ],
+}
+
+testData.stringSubstitutionNoParameters = {
+  operator: 'stringSubstitution',
+  children: ['This sentence has no replacements.', 'nothing', 'will', 'happen'],
+}
+
+testData.stringSubstitutionNoReplacements = {
+  operator: 'stringSubstitution',
+  children: ['Your name is %2 %1 but we have nothing to replace them with'],
 }
 
 // API operator

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -546,7 +546,13 @@ testData.stringSubstitutionMultiple = {
 
 testData.stringSubstitutionNonStringReplacements = {
   operator: 'stringSubstitution',
-  children: ['We have %1 people listed: %2', 2, { value: ['Boba', 'Mando'] }],
+  children: [
+    'We have %1 %2 listed with an average value of %3: %4',
+    2,
+    'people',
+    4.53,
+    { value: ['Boba', 'Mando'] },
+  ],
 }
 
 testData.stringSubstitutionTooManyReplacements = {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -527,6 +527,65 @@ testData.singleApplicationProperty_depth2 = {
   children: ['application.questions.q2'],
 }
 
+// String substitution
+
+testData.stringSubstitutionSingle = {
+  operator: 'stringSubstitution',
+  children: ['Hello, %1, welcome to our site.', 'friend'],
+}
+
+testData.stringSubstitutionMultiple = {
+  operator: 'stringSubstitution',
+  children: [
+    'There are %1 kinds of people in the world:\nthose who understand %2 and those who %3',
+    '10',
+    { value: 'binary' },
+    "don't",
+  ],
+}
+testData.stringSubstitutionNonStringReplacements = {
+  operator: 'stringSubstitution',
+  children: ['We have %1 people listed: %2', 2, { value: ['Boba', 'Mando'] }],
+}
+
+testData.stringSubstitutionTooManyReplacements = {
+  operator: 'stringSubstitution',
+  children: ['The price of milk is %1 per %2', '$2.30', 'liter', 'gallon', '$5.00'],
+}
+
+testData.stringSubstitutionTooFewReplacements = {
+  operator: 'stringSubstitution',
+  children: ["The applicant's name is %1 %2 %3.", 'Carl', 'Smith'],
+}
+
+testData.stringSubstitutionParametersNonOrdered = {
+  operator: 'stringSubstitution',
+  children: ['%2 out of every %3 people are %1', 'stupid', 'Two', 3],
+}
+
+testData.stringSubstitutionParametersNonOrderedAndTooFew = {
+  operator: 'stringSubstitution',
+  children: ['%2 out of every %3 people are %1', 'stupid', 'Two'],
+}
+
+testData.stringSubstitutionIgnoreLiteral = {
+  operator: 'stringSubstitution',
+  children: [
+    `We don't want \%2 to be replaced but we do want %1 to be replaced, and we want there to be a single \\ here.`,
+    'this',
+  ],
+}
+testData.stringSubstitutionParametersNotSequential = {
+  operator: 'stringSubstitution',
+  children: [
+    `It shouldn't matter if %10 are big %100 between %101 %200`,
+    'there',
+    'gaps',
+    'parameter',
+    'numbers',
+  ],
+}
+
 // API operator
 
 testData.APIisUnique = {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -543,6 +543,7 @@ testData.stringSubstitutionMultiple = {
     "don't",
   ],
 }
+
 testData.stringSubstitutionNonStringReplacements = {
   operator: 'stringSubstitution',
   children: ['We have %1 people listed: %2', 2, { value: ['Boba', 'Mando'] }],

--- a/src/modules/expression-evaluator/src/types.ts
+++ b/src/modules/expression-evaluator/src/types.ts
@@ -43,5 +43,7 @@ type Operator =
   | '+'
   | 'REGEX'
   | 'objectProperties'
+  | 'stringSubstitution'
+  | 'API'
   | 'pgSQL'
   | 'graphQL'


### PR DESCRIPTION
Implements #158.

Did this at the start of the break. Now that @nmadruga has made progress on the start/submission pages, this will probably be useful sooner rather than later (as it'll be a lot easier than multiple CONCATs).

Can see implementation by reading and running test suite.

One thing I didn't (yet) implement is escaping when literal `(%1)` values are required in a string. Probably not a priority as it's very unusual to have a percent character before a number (unless writing documentation for a modulus operator, perhaps), so can do it later if required.

Once approved, will update package and make new PRs to upgrade the module in front and back-ends.