### PR TITLE
#159 Refactor for evaluator package update

### DIFF
--- a/database/insertData.js
+++ b/database/insertData.js
@@ -470,7 +470,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                 }
               }
@@ -491,23 +491,23 @@ const queries = [
                 parameterQueries: {
                   first_name: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q1.text" } }]
+                    children: ["applicationData.responses.Q1.text"]
                   }
                   last_name: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q2.text" } }]
+                    children: ["applicationData.responses.Q2.text"]
                   }
                   username: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q3.text" } }]
+                    children: ["applicationData.responses.Q3.text"]
                   }
                   password_hash: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q5.text" } }]
+                    children: ["applicationData.responses.Q5.text"]
                   }
                   email: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q4.text" } }]
+                    children: ["applicationData.responses.Q4.text"]
                   }
                 }
               }
@@ -518,7 +518,7 @@ const queries = [
                 parameterQueries: {
                   username: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q3.text" } }]
+                    children: ["applicationData.responses.Q3.text"]
                   }
                   permissionNames: { value: ["applyCompanyRego"] }
                 }
@@ -530,7 +530,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                   newStatus: { value: "Completed" }
                 }
@@ -542,7 +542,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                   newOutcome: { value: "Approved" }
                 }
@@ -558,16 +558,12 @@ const queries = [
                       { value: "Output concatenation: The user " }
                       {
                         operator: "objectProperties"
-                        children: [
-                          { value: { objectIndex: 1, property: "username" } }
-                        ]
+                        children: ["output.username"]
                       }
                       { value: "'s registration has been " }
                       {
                         operator: "objectProperties"
-                        children: [
-                          { value: { objectIndex: 1, property: "newOutcome" } }
-                        ]
+                        children: ["output.newOutcome"]
                       }
                     ]
                   }

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -896,7 +896,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "record_id" } }]
+                    children: ["applicationData.record_id"]
                   }
                 }
               }
@@ -913,7 +913,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "record_id" } }]
+                    children: ["applicationData.record_id"]
                   }
                   newStatus: { value: "Submitted" }
                 }
@@ -1082,7 +1082,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                 }
               }
@@ -1093,23 +1093,23 @@ const queries = [
                 parameterQueries: {
                   first_name: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q1.text" } }]
+                    children: ["applicationData.responses.Q1.text"]
                   }
                   last_name: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q2.text" } }]
+                    children: ["applicationData.responses.Q2.text"]
                   }
                   username: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q3.text" } }]
+                    children: ["applicationData.responses.Q3.text"]
                   }
                   password_hash: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q5.text" } }]
+                    children: ["applicationData.responses.Q5.text"]
                   }
                   email: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "responses.Q4.text" } }]
+                    children: ["applicationData.responses.Q4.text"]
                   }
                 }
               }
@@ -1120,7 +1120,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                   newStatus: { value: "Completed" }
                 }
@@ -1132,7 +1132,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                   newOutcome: { value: "Approved" }
                 }
@@ -1372,7 +1372,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                 }
               }
@@ -1383,7 +1383,7 @@ const queries = [
                 parameterQueries: {
                   applicationId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "applicationId" } }]
+                    children: ["applicationData.applicationId"]
                   }
                   newStatus: { value: "Submitted" }
                 }
@@ -1400,7 +1400,7 @@ const queries = [
                 parameterQueries: {
                   reviewId: {
                     operator: "objectProperties"
-                    children: [{ value: { property: "record_id" } }]
+                    children: ["applicationData.record_id"]
                   }
                   newStatus: { value: "Draft" }
                 }

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -56,7 +56,7 @@ const queries = [
                             children: [
                               {
                                 operator: "objectProperties"
-                                children: [{ value: { property: "Q1.text" } }]
+                                children: ["responses.Q1.text"]
                               }
                               { value: null }
                             ]
@@ -66,7 +66,7 @@ const queries = [
                             children: [
                               {
                                 operator: "objectProperties"
-                                children: [{ value: { property: "Q1.text" } }]
+                                children: ["responses.Q1.text"]
                               }
                               { value: "" }
                             ]
@@ -80,7 +80,7 @@ const queries = [
                           children: [
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q1.text" } }]
+                              children: ["responses.Q1.text"]
                             }
                             ", what is your last name?"
                           ]
@@ -100,20 +100,12 @@ const queries = [
                             "Current User: "
                             {
                               operator: "objectProperties"
-                              children: [
-                                {
-                                  value: { objectIndex: 1, property: "firstName" }
-                                }
-                              ]
+                              children: ["currentUser.firstName"]
                             }
                             " "
                             {
                               operator: "objectProperties"
-                              children: [
-                                {
-                                  value: { objectIndex: 1, property: "lastName" }
-                                }
-                              ]
+                              children: ["currentUser.lastName"]
                             }
                           ]
                         }
@@ -123,12 +115,12 @@ const queries = [
                             "The new user's name is: "
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q1.text" } }]
+                              children: ["responses.Q1.text"]
                             }
                             " "
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q2.text" } }]
+                              children: ["responses.Q2.text"]
                             }
                           ]
                         }
@@ -145,7 +137,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "Q1.text" } }]
+                            children: ["responses.Q1.text"]
                           }
                           { value: "" }
                         ]
@@ -158,7 +150,7 @@ const queries = [
                           { value: "username" }
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: "unique" }
                         ]
@@ -177,7 +169,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           {
                             value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
@@ -198,7 +190,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: "^[\\\\S]{8,}$" }
                         ]
@@ -224,22 +216,21 @@ const queries = [
                           operator: "CONCAT"
                           type: "array"
                           children: [
-                            []
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q1.text" } }]
+                              children: ["responses.Q1.text"]
                             }
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q2.text" } }]
+                              children: ["responses.Q2.text"]
                             }
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q3.text" } }]
+                              children: ["responses.Q3.text"]
                             }
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q4.text" } }]
+                              children: ["responses.Q4.text"]
                             }
                           ]
                         }
@@ -279,7 +270,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "Q6.text" } }]
+                            children: ["responses.Q6.text"]
                           }
                           { value: "Manufacturer" }
                         ]
@@ -306,7 +297,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "Q6.text" } }]
+                            children: ["responses.Q6.text"]
                           }
                           { value: "Distributor" }
                         ]
@@ -334,7 +325,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "Q6.text" } }]
+                            children: ["responses.Q6.text"]
                           }
                           { value: "Importer" }
                         ]
@@ -388,7 +379,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "Q11.text" } }]
+                            children: ["responses.Q11.text"]
                           }
                           { value: "magicword" }
                         ]
@@ -401,14 +392,12 @@ const queries = [
                             "You chose "
                             {
                               operator: "objectProperties"
-                              children: [{ value: { property: "Q10.text" } }]
+                              children: ["responses.Q10.text"]
                             }
                             " (index number "
                             {
                               operator: "objectProperties"
-                              children: [
-                                { value: { property: "Q10.optionIndex" } }
-                              ]
+                              children: ["responses.Q10.optionIndex"]
                             }
                             ") in the API lookup"
                           ]
@@ -447,7 +436,7 @@ const queries = [
                           "Other"
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "Q12.text" } }]
+                            children: ["responses.Q12.text"]
                           }
                         ]
                       }

--- a/database/insertData.js
+++ b/database/insertData.js
@@ -634,7 +634,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: ".+" }
                         ]
@@ -691,7 +691,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "S1Q3.text" } }]
+                            children: ["responses.S1Q3.text"]
                           }
                           { value: "International" }
                         ]
@@ -720,7 +720,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "S1Q3.text" } }]
+                            children: ["responses.S1Q3.text"]
                           }
                           { value: "National" }
                         ]
@@ -737,7 +737,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: ".+" }
                         ]
@@ -749,7 +749,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "S1Q3.text" } }]
+                            children: ["responses.S1Q3.text"]
                           }
                           { value: "National" }
                         ]
@@ -766,7 +766,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: ".+" }
                         ]
@@ -778,7 +778,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "S1Q3.text" } }]
+                            children: ["responses.S1Q3.text"]
                           }
                           { value: "National" }
                         ]
@@ -810,7 +810,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: ".+" }
                         ]
@@ -829,7 +829,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: ".+" }
                         ]
@@ -973,7 +973,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: ".+" }
                         ]
@@ -1003,7 +1003,7 @@ const queries = [
                           { value: "username" }
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: "unique" }
                         ]
@@ -1022,7 +1022,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           {
                             value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
@@ -1043,7 +1043,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: "^[\\\\S]{8,}$" }
                         ]
@@ -1206,7 +1206,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           {
                             value: "^[A-Za-z0-9.]+@[A-Za-z0-9]+\\\\.[A-Za-z0-9.]+$"
@@ -1235,7 +1235,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: "^[0-9]+$" }
                         ]
@@ -1322,7 +1322,7 @@ const queries = [
                         children: [
                           {
                             operator: "objectProperties"
-                            children: [{ value: { property: "thisResponse" } }]
+                            children: ["responses.thisResponse"]
                           }
                           { value: "^[0-9]+$" }
                         ]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.0.0",
-    "@openmsupply/expression-evaluator": "^1.2.1",
+    "@openmsupply/expression-evaluator": "^1.3.0",
     "@types/jsonwebtoken": "^8.5.0",
     "concurrently": "^5.3.0",
     "fastify": "^3.2.1",

--- a/src/components/triggersAndActions.ts
+++ b/src/components/triggersAndActions.ts
@@ -110,7 +110,7 @@ export async function processTrigger(payload: TriggerPayload) {
 
   for (const action of result) {
     const condition = await evaluateExpression(action.condition, {
-      objects: [applicationData],
+      objects: { applicationData },
       pgConnection: DBConnect,
     })
     if (condition) {
@@ -160,7 +160,7 @@ export async function processTrigger(payload: TriggerPayload) {
         application_data: applicationData,
         parameter_queries: action.parameter_queries,
       }
-      const result = await executeAction(actionPayload, actionLibrary, [outputCumulative])
+      const result = await executeAction(actionPayload, actionLibrary, { output: outputCumulative })
       outputCumulative = { ...outputCumulative, ...result.output }
       if (result.status === 'Fail') console.log(result.error_log)
     } catch (err) {
@@ -192,10 +192,10 @@ async function evaluateParameters(
 export async function executeAction(
   payload: ActionPayload,
   actionLibrary: ActionLibrary,
-  additionalObjects: BasicObject[] = []
+  additionalObjects: BasicObject = {}
 ): Promise<ActionQueueExecutePayload> {
   const evaluatorParams = {
-    objects: [payload.application_data, ...additionalObjects],
+    objects: { applicationData: payload.application_data, ...additionalObjects },
     pgConnection: DBConnect, // Add graphQLConnection, Fetch (API) here when required
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@openmsupply/expression-evaluator@^1.2.1":
-  version "1.2.1"
-  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.2.1/cfb52b96af1dc0fc0f6ce52f9ac6905d4241ba6fde1b4b7e4a5b5c62680a3153#fa247757a6893f9a563ca1cd2975097ae9e0dbc7"
-  integrity sha512-tBbMvCHpP2IstLNvxoig8jJFBTN+8u0sU/5T9+GaR/1kFoMS4s0zPAmNL0gy17vCGSJsdaNNVX2uMPzwiR70hA==
+"@openmsupply/expression-evaluator@^1.3.0":
+  version "1.3.0"
+  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.3.0/5cfbd4ecc2a4cf98c9eb8e55077533b2faa63fc4ed214f4adeb313b93f1180f8#e81aa987a9dc9947811ab27f60457aec71e4c58d"
+  integrity sha512-WTbe3yRFGi4w1eWjoPsNHgfoo0v+dCyfdxGutj8Z+uhmoPQSqKS8tVm+tWjP4/GSab7VPWijNM3782ML/CziOQ==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"


### PR DESCRIPTION
Fixes #159. Refactors evaluator queries to accomodate changes made in #161.

**NOTE**: Must run `yarn install` to upgrade evaluator package version. (If you go back to another branch, you'll need to run it again to revert to previous version -- these changes are breaking changes and incompatible between evaluator version 1.2.1 and 1.3.0 (the latest))

Needs to use [front-end PR branch #238](https://github.com/openmsupply/application-manager-web-app/pull/238) in conjunction to test.

Best way to test: Go through the "Feature Showcase" template and check all the visibility/dynamic parameters/validation works as expected when filling in application, and check all Actions run as expected when submitting.