### PR TITLE
#176 Update evaluator version and implement stringSubstitution

### DIFF
--- a/database/insertData.js
+++ b/database/insertData.js
@@ -14,25 +14,23 @@ const queries = [
           name: "Test -- General Registration"
           isLinear: false
           startMessage: {
-            operator: "CONCAT"
+            operator: "stringSubstitution"
             children: [
-              "## This is the general registration for feature showcase\\nHi, "
+              "## This is the general registration for feature showcase\\nHi, %1. You will need to provide:\\n- Proof of identity (Passport, Drivers license)\\n- Proof of your medical certification\\n- Drug ingredient list\\n- Product images\\n- Packging images"
               {
                 operator: "objectProperties"
                 children: ["currentUser.firstName"]
               }
-              ". You will need to provide:\\n- Proof of identity (Passport, Drivers license)\\n- Proof of your medical certification\\n- Drug ingredient list\\n- Product images\\n- Packging images"
             ]
           }
           submissionMessage: {
-            operator: "CONCAT"
+            operator: "stringSubstitution"
             children: [
-              "### Application Submitted!\\nThanks, "
+              "### Application Submitted!\\nThanks, %1."
               {
                 operator: "objectProperties"
                 children: ["currentUser.firstName"]
               }
-              ". "
             ]
           }
           status: AVAILABLE
@@ -98,13 +96,13 @@ const queries = [
                       validationMessage: "You need a first name."
                       parameters: {
                         label: {
-                          operator: "CONCAT"
+                          operator: "stringSubstitution"
                           children: [
+                            "%1, what is your last name?"
                             {
                               operator: "objectProperties"
                               children: ["responses.Q1.text"]
                             }
-                            ", what is your last name?"
                           ]
                         }
                       }
@@ -117,14 +115,13 @@ const queries = [
                       category: INFORMATION
                       parameters: {
                         title: {
-                          operator: "CONCAT"
+                          operator: "stringSubstitution"
                           children: [
-                            "Current User: "
+                            "Current User: %1 %2"
                             {
                               operator: "objectProperties"
                               children: ["currentUser.firstName"]
                             }
-                            " "
                             {
                               operator: "objectProperties"
                               children: ["currentUser.lastName"]
@@ -132,14 +129,13 @@ const queries = [
                           ]
                         }
                         text: {
-                          operator: "CONCAT"
+                          operator: "stringSubstitution"
                           children: [
-                            "The new user's name is: "
+                            "The new user's name is: %1 %2"
                             {
                               operator: "objectProperties"
                               children: ["responses.Q1.text"]
                             }
-                            " "
                             {
                               operator: "objectProperties"
                               children: ["responses.Q2.text"]
@@ -409,19 +405,17 @@ const queries = [
                       parameters: {
                         title: "This has appeared because you typed 'magicword' above."
                         text: {
-                          operator: "CONCAT"
+                          operator: "stringSubstitution"
                           children: [
-                            "You chose "
+                            "You chose %1 (index number %2) in the API lookup"
                             {
                               operator: "objectProperties"
                               children: ["responses.Q10.text"]
                             }
-                            " (index number "
                             {
                               operator: "objectProperties"
                               children: ["responses.Q10.optionIndex"]
                             }
-                            ") in the API lookup"
                           ]
                         }
                       }
@@ -573,14 +567,13 @@ const queries = [
                 sequence: 6
                 parameterQueries: {
                   message: {
-                    operator: "CONCAT"
+                    operator: "stringSubstitution"
                     children: [
-                      { value: "Output concatenation: The user " }
+                      "Output concatenation: The user %1's registration has been %2"
                       {
                         operator: "objectProperties"
                         children: ["output.username"]
                       }
-                      { value: "'s registration has been " }
                       {
                         operator: "objectProperties"
                         children: ["output.newOutcome"]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.0.0",
-    "@openmsupply/expression-evaluator": "^1.3.0",
+    "@openmsupply/expression-evaluator": "^1.4.0",
     "@types/jsonwebtoken": "^8.5.0",
     "concurrently": "^5.3.0",
     "fastify": "^3.2.1",

--- a/src/modules/expression-evaluator/expression-evaluate-gui/package.json
+++ b/src/modules/expression-evaluator/expression-evaluate-gui/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {},
   "dependencies": {
     "@material-ui/core": "^4.11.0",
-    "@openmsupply/expression-evaluator": "^1.2.1",
+    "@openmsupply/expression-evaluator": "^1.4.0",
     "concurrently": "^5.3.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/src/modules/expression-evaluator/package.json
+++ b/src/modules/expression-evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmsupply/expression-evaluator",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Module to evaluate dynamic expressions for the openMsupply Application Manager project",
   "main": "lib/evaluateExpression.js",
   "types": "lib/evaluateExpression.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@openmsupply/expression-evaluator@^1.3.0":
-  version "1.3.0"
-  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.3.0/5cfbd4ecc2a4cf98c9eb8e55077533b2faa63fc4ed214f4adeb313b93f1180f8#e81aa987a9dc9947811ab27f60457aec71e4c58d"
-  integrity sha512-WTbe3yRFGi4w1eWjoPsNHgfoo0v+dCyfdxGutj8Z+uhmoPQSqKS8tVm+tWjP4/GSab7VPWijNM3782ML/CziOQ==
+"@openmsupply/expression-evaluator@^1.4.0":
+  version "1.4.0"
+  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.4.0/1c06ed60b0254f5c3c6f8e03bd76e7d94f1668c5032b3595873970a1cb7c77b5#1da30d7a74208b2fcba2de472e751256d0b886a7"
+  integrity sha512-frktwDBpewYNpCaSk3qTsUnFrEnUztzw4ppKr1q1x3MmK5JD/U4B6Z43EqZUgedbDAco6w2/Ygd32qxUFn+lwQ==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"


### PR DESCRIPTION
Implement #176. 

Requires [front-end PR #263](https://github.com/openmsupply/application-manager-web-app/pull/263) to see it in use.

Have re-written several of the CONCAT expressions in the FeatureShowcase template to use `stringSubstitution` instead.

(Don't forget to `yarn install` to update package)