### PR TITLE
#190 Evaluator -- Conditional operator

### DIFF
--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -116,6 +116,20 @@ Adds any number of number nodes together
 - Input: 1 or more nodes of **number** type.
 - Output: **number**
 
+## ? (Conditional)
+
+Returns a different value depending on whether an expression is `true` or `false`.
+
+- Input:
+
+  - 1st child node returns `true` or `false`
+  - 2nd node returns value if `true`
+  - 3rd node returns value if `false`
+
+- Output: the result of either child 1 or child 2
+
+Functionally equivalent to javascript ternary (`?`) operator
+
 ## REGEX
 
 Compares an input string with a regular expression string and returns whether it matches.

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -240,6 +240,32 @@ test('Testing Adding 4 numbers', () => {
   })
 })
 
+// Conditional (?) operator
+
+test('Basic conditional', () => {
+  return evaluateExpression(testData.CONDITIONAL_basic).then((result: any) => {
+    expect(result).toEqual('A')
+  })
+})
+
+test('Conditional with Addition', () => {
+  return evaluateExpression(testData.CONDITIONAL_with_addition).then((result: any) => {
+    expect(result).toEqual('Correct')
+  })
+})
+
+test('Conditional with Logical expression', () => {
+  return evaluateExpression(testData.CONDITIONAL_logical_expression).then((result: any) => {
+    expect(result).toEqual('Expression is True')
+  })
+})
+
+test('Conditional with False Logical expression', () => {
+  return evaluateExpression(testData.CONDITIONAL_logical_expression_false).then((result: any) => {
+    expect(result).toEqual('Expression is False')
+  })
+})
+
 // REGEX operator
 
 test('Testing Regex - Email validation', () => {
@@ -595,7 +621,7 @@ test('Input is an array', () => {
   })
 })
 
-test('Input is an string', () => {
+test('Input is a string', () => {
   return evaluateExpression('Friday drinks?').then((result: any) => {
     expect(result).toEqual('Friday drinks?')
   })

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -77,6 +77,9 @@ export default async function evaluateExpression(
           return acc + child
         }, 0)
 
+      case '?':
+        return childrenResolved[0] ? childrenResolved[1] : childrenResolved[2]
+
       case 'objectProperties':
         if (Object.entries(params).length === 0)
           return 'No parameters received for objectProperties node'

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -454,6 +454,54 @@ testData.PLUS_4Nums = {
   ],
 }
 
+// CONDITIONAL
+
+testData.CONDITIONAL_basic = { operator: '?', children: [true, 'A', 'B'] }
+
+testData.CONDITIONAL_equality_child_node = {
+  operator: '?',
+  children: [{ operator: '=', children: [1, 2] }, 'Correct', 'Wrong'],
+}
+
+testData.CONDITIONAL_with_addition = {
+  operator: '?',
+  children: [
+    { operator: '=', children: [{ operator: '+', children: [7.5, 19] }, 26.5] },
+    'Correct',
+    'Wrong',
+  ],
+}
+
+testData.CONDITIONAL_logical_expression = {
+  operator: '?',
+  children: [
+    {
+      operator: 'AND',
+      children: [
+        { operator: '=', children: [{ operator: '+', children: [7.5, 19] }, 26.5] },
+        { operator: '!=', children: ['five', 'four'] },
+      ],
+    },
+    'Expression is True',
+    'Expression is False',
+  ],
+}
+
+testData.CONDITIONAL_logical_expression_false = {
+  operator: '?',
+  children: [
+    {
+      operator: 'OR',
+      children: [
+        { operator: '=', children: [{ operator: '+', children: [7, 19] }, 26.5] },
+        { operator: '!=', children: ['five', 'five'] },
+      ],
+    },
+    'Expression is True',
+    'Expression is False',
+  ],
+}
+
 // REGEX
 
 testData.REGEX_check_email = {

--- a/src/modules/expression-evaluator/src/types.ts
+++ b/src/modules/expression-evaluator/src/types.ts
@@ -41,6 +41,7 @@ type Operator =
   | '='
   | '!= '
   | '+'
+  | '?'
   | 'REGEX'
   | 'objectProperties'
   | 'stringSubstitution'


### PR DESCRIPTION
Very small improvement, so I just squeezed this in. Implements #190 which adds a Conditional `?` operator to evaluator. Works exactly like the javascript ternary (`?`) operator.

The actual implementation was two lines of code. Docs and tests slightly more :) 

`yarn test ./src/modules/expression-evaluator/src/evaluateExpression.test.ts` to run evaluator test suite. (On newly initialised database)