### PR TITLE
#204 Add ON_REVIEW_CREATE action to two templates

### DIFF
--- a/database/insertData/01_template_A_featureShowcase.js
+++ b/database/insertData/01_template_A_featureShowcase.js
@@ -457,7 +457,7 @@ exports.queries = [
                       isRequired: true
                     }
                     {
-                      id:10018
+                      id: 10018
                       code: "Q12"
                       index: 18
                       title: "Role"
@@ -622,6 +622,17 @@ exports.queries = [
                   message: {
                     value: "Testing parallel actions -- This message is Asynchronous. \\nEven though it is last in the Actions list, it'll probably appear first."
                   }
+                }
+              }
+              {
+                actionCode: "changeStatus"
+                trigger: ON_REVIEW_CREATE
+                parameterQueries: {
+                  reviewId: {
+                    operator: "objectProperties"
+                    children: ["applicationData.record_id"]
+                  }
+                  newStatus: { value: "Draft" }
                 }
               }
             ]

--- a/database/insertData/01_template_B_companyRegistration.js
+++ b/database/insertData/01_template_B_companyRegistration.js
@@ -278,6 +278,17 @@ exports.queries = [
                 }
               }
               {
+                actionCode: "changeStatus"
+                trigger: ON_REVIEW_CREATE
+                parameterQueries: {
+                  reviewId: {
+                    operator: "objectProperties"
+                    children: ["applicationData.record_id"]
+                  }
+                  newStatus: { value: "Draft" }
+                }
+              }
+              {
                 actionCode: "changeOutcome"
                 trigger: ON_REVIEW_SUBMIT
                 sequence: 1


### PR DESCRIPTION
I think this is all there is to this one -- the Action already existed, so just added it to two templates that should have it.

Edit: Original issue is [front-end #204,](https://github.com/openmsupply/application-manager-web-app/issues/204) but this is purely a back-end change.