### PR TITLE
#201 Evaluator -- stringSubstitution bug

### DIFF
--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -368,6 +368,14 @@ test('String substitution - no replacements supplied', () => {
   })
 })
 
+test('String substitution - some parameters empty strings', () => {
+  return evaluateExpression(testData.stringSubstitutionEmptyStringInReplacements).then(
+    (result: any) => {
+      expect(result).toBe('You like: \\n-Cake\\n-Candy')
+    }
+  )
+})
+
 // API operator
 test('API: Check username is unique', () => {
   return evaluateExpression(testData.APIisUnique, {

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -100,7 +100,7 @@ export default async function evaluateExpression(
         )
         let i = 0
         return parameters.reduce((outputString, param) => {
-          return outputString.replace(param, replacements[i] ? replacements[i++] : '')
+          return outputString.replace(param, replacements[i] !== undefined ? replacements[i++] : '')
         }, origString)
 
       case 'API':

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -644,6 +644,11 @@ testData.stringSubstitutionNoReplacements = {
   children: ['Your name is %2 %1 but we have nothing to replace them with'],
 }
 
+testData.stringSubstitutionEmptyStringInReplacements = {
+  operator: 'stringSubstitution',
+  children: ['You like: %1%2%3', '', '\\n-Cake', '\\n-Candy'],
+}
+
 // API operator
 
 testData.APIisUnique = {


### PR DESCRIPTION
Very quick fix. 

Annoying how in javascript an empty string evaluates to `false` -- that's caught me out many times now. Anyway, that's all it was. 

Added additional test to catch this.