### PR TITLE
#188 Review levels in ReviewTest template

### DIFF
--- a/database/insertData/00A_permission_policies.js
+++ b/database/insertData/00A_permission_policies.js
@@ -1,0 +1,71 @@
+/*
+Basic Permission Policies 
+*/
+exports.queries = [
+  // oneTimeApply -- used for UserRegistration
+  `mutation createPolicy {
+    createPermissionPolicy(
+      input: {
+        permissionPolicy: {
+          id: 1000
+          name: "oneTimeApply"
+          rules: {
+            application: {
+              view: { template_id: "jwtPermission_bigint_templateId" }
+            }
+          }
+          type: APPLY
+        }
+      }
+    ) {
+      permissionPolicy {
+        name
+      }
+    }
+  }`,
+  // basicApply
+  `mutation createPolicy {
+    createPermissionPolicy(
+      input: {
+        permissionPolicy: {
+          id: 2000
+          name: "basicApply"
+          rules: {
+            application: {
+              view: {
+                template_id: "jwtPermission_bigint_templateId"
+                user_id: "jwtUserDetails_bigint_userId"
+              }
+            }
+          }
+          type: APPLY
+        }
+      }
+    ) {
+      permissionPolicy {
+        name
+      }
+    }
+  }`,
+  // basicReview
+  `mutation createPolicy {
+    createPermissionPolicy(
+      input: {
+        permissionPolicy: {
+          id: 3000
+          name: "basicReview"
+          rules: {
+            application: {
+              view: { template_id: "jwtPermission_bigint_templateId" }
+            }
+          }
+          type: REVIEW
+        }
+      }
+    ) {
+      permissionPolicy {
+        name
+      }
+    }
+  }`,
+]

--- a/database/insertData/00B_permission_names.js
+++ b/database/insertData/00B_permission_names.js
@@ -1,0 +1,75 @@
+/*
+Basic permissionNames, and associate with policies 
+*/
+exports.queries = [
+  // applyUserRegistration
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: { 
+          id: 1000
+          name: "applyUserRegistration", permissionPolicyId: 1000 }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  // applyCompanyRego
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: { 
+          id: 2000
+          name: "applyCompanyRego", permissionPolicyId: 2000 }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  // applyReviewTest
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: { 
+          id: 3000
+          name: "applyReviewTest", permissionPolicyId: 2000 }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  // reviewCompanyRego
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: { 
+          id: 4000
+          name: "reviewCompanyRego", permissionPolicyId: 3000 }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  // reviewReviewTest
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: { 
+          id: 5000
+          name: "reviewReviewTest", permissionPolicyId: 3000 }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+]

--- a/database/insertData/01_template_A_featureShowcase.js
+++ b/database/insertData/01_template_A_featureShowcase.js
@@ -815,6 +815,13 @@ exports.queries = [
               }
             ]
           }
+          templatePermissionsUsingId: {
+            create: [
+              {
+                id: 1000, permissionNameId: 1000
+              }
+            ]
+          }
         }
       }
     ) {

--- a/database/insertData/01_template_B_companyRegistration.js
+++ b/database/insertData/01_template_B_companyRegistration.js
@@ -333,6 +333,12 @@ exports.queries = [
               }
             ]
           }
+          templatePermissionsUsingId: {
+            create: [
+              { id: 2000, permissionNameId: 2000 }
+              { id: 2001, permissionNameId: 4000, stageNumber: 1 }
+            ]
+          }
         }
       }
     ) {

--- a/database/insertData/01_template_C_userRegistration.js
+++ b/database/insertData/01_template_C_userRegistration.js
@@ -139,9 +139,7 @@ exports.queries = [
               }
             ]
           }
-          templateStagesUsingId: {
-            create: [{ number: 1, title: "Automatic" }]
-          }
+          templateStagesUsingId: { create: [{ number: 1, title: "Automatic" }] }
           templateActionsUsingId: {
             create: [
               {
@@ -206,6 +204,9 @@ exports.queries = [
                 }
               }
             ]
+          }
+          templatePermissionsUsingId: {
+            create: [{ id: 3000, permissionNameId: 1000 }]
           }
         }
       }

--- a/database/insertData/01_template_D_basicReviewTesting.js
+++ b/database/insertData/01_template_D_basicReviewTesting.js
@@ -274,6 +274,14 @@ exports.queries = [
               }
             ]
           }
+          templatePermissionsUsingId: {
+            create: [
+              { id: 4000, permissionNameId: 2000 }
+              { id: 4001, permissionNameId: 5000, stageNumber: 1, level: 1 }
+              { id: 4002, permissionNameId: 5000, stageNumber: 2, level: 1 }
+              { id: 4003, permissionNameId: 5000, stageNumber: 2, level: 2 }
+            ]
+          }
         }
       }
     ) {

--- a/database/insertData/02_users.js
+++ b/database/insertData/02_users.js
@@ -122,7 +122,7 @@ exports.queries = [
     }
   }`,
   //
-  // Non Registered User with Permissions
+  // Non Registered User with Permissions for UserRegistration only
   // Password is blank
   `mutation {
     createUser(
@@ -131,27 +131,7 @@ exports.queries = [
           email: ""
           passwordHash: "$2a$10$UIfa3GTUbOS92Ygy/UpqheTngGo3O54Q5UOnJ5CBlra9LYCcr4IGq"
           username: "nonRegistered"
-          permissionJoinsUsingId: {
-            create: [
-              {
-                permissionNameToPermissionNameId: {
-                  create: {
-                    name: "applyUserRegistration"
-                    templatePermissionsUsingId: { create: [{ templateId: 1 }] }
-                    permissionPolicyToPermissionPolicyId: {
-                      create: { type: APPLY, name: "oneTimeApply", rules: {
-                        application: {
-                          view: {
-                            template_id: "jwtPermission_bigint_templateId"
-                          }
-                        }
-                      } }
-                    }
-                  }
-                }
-              }
-            ]
-          }
+          permissionJoinsUsingId: { create: { permissionNameId: 1000 } }
         }
       }
     ) {
@@ -161,47 +141,57 @@ exports.queries = [
     }
   }`,
   // Registered User Permissions
-  `mutation {
-    createPermissionPolicy(
-      input: {
-        permissionPolicy: {
-          name: "basicApply"
-          permissionNamesUsingId: {
-            create: [
-              {
-                name: "applyCompanyRego"
-                templatePermissionsUsingId: { create: { templateId: 2 } }
-                permissionJoinsUsingId: {
-                  create: [
-                    { userId: 1 }
-                    { userId: 2 }
-                    { userId: 3 }
-                    { userId: 4 }
-                  ]
-                }
-              }
-              {
-                name: "applyReviewTest"
-                templatePermissionsUsingId: { create: { templateId: 4 } }
-                permissionJoinsUsingId: { create: [{ userId: 1 }, { userId: 2 }] }
-              }
-            ]
-          }
-          type: APPLY
-          rules: {
-            application: {
-              view: {
-                template_id: "jwtPermission_bigint_templateId"
-                user_id: "jwtUserDetails_bigint_userId"
-              }
-            }
-          }
-        }
-      }
+  `mutation userToPermissionNameJoin {
+    createPermissionJoin(
+      input: { permissionJoin: { permissionNameId: 2000, userId: 1 } }
     ) {
-      permissionPolicy {
+      permissionName {
         name
-        type
+      }
+    }
+  }`,
+  `mutation userToPermissionNameJoin {
+    createPermissionJoin(
+      input: { permissionJoin: { permissionNameId: 2000, userId: 2 } }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  `mutation userToPermissionNameJoin {
+    createPermissionJoin(
+      input: { permissionJoin: { permissionNameId: 2000, userId: 3 } }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  `mutation userToPermissionNameJoin {
+    createPermissionJoin(
+      input: { permissionJoin: { permissionNameId: 2000, userId: 4 } }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  `mutation userToPermissionNameJoin {
+    createPermissionJoin(
+      input: { permissionJoin: { permissionNameId: 3000, userId: 1 } }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  `mutation userToPermissionNameJoin {
+    createPermissionJoin(
+      input: { permissionJoin: { permissionNameId: 3000, userId: 2 } }
+    ) {
+      permissionName {
+        name
       }
     }
   }`,
@@ -214,31 +204,9 @@ exports.queries = [
           passwordHash: "$2a$10$5R5ruFOLgrjOox5oH0I67.Rez7qGCEwf2a60Pe2TpfmIN99Dr0uW."
           permissionJoinsUsingId: {
             create: [
-              { permissionNameId: 1 }
-              { permissionNameId: 2 }
-              {
-                permissionNameToPermissionNameId: {
-                  create: {
-                    name: "reviewCompanyRego"
-                    templatePermissionsUsingId: {
-                      create: [{ templateId: 2, stageNumber: 1 }]
-                    }
-                    permissionPolicyToPermissionPolicyId: {
-                      create: {
-                        type: REVIEW
-                        name: "basicReview"
-                        rules: {
-                          application: {
-                            view: {
-                              template_id: "jwtPermission_bigint_templateId"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+              { permissionNameId: 1000 }
+              { permissionNameId: 2000 }
+              { permissionNameId: 4000 }
             ]
           }
         }

--- a/database/insertData/02_users.js
+++ b/database/insertData/02_users.js
@@ -141,54 +141,32 @@ exports.queries = [
     }
   }`,
   // Registered User Permissions
-  `mutation userToPermissionNameJoin {
-    createPermissionJoin(
-      input: { permissionJoin: { permissionNameId: 2000, userId: 1 } }
+`mutation joinUsersToPermissionName {
+    updatePermissionName(
+      input: {
+        patch: {
+          permissionJoinsUsingId: {
+            create: [{ userId: 1 }, { userId: 2 }, { userId: 3 }, { userId: 4 }]
+          }
+        }
+        id: 2000
+      }
     ) {
       permissionName {
         name
       }
     }
   }`,
-  `mutation userToPermissionNameJoin {
-    createPermissionJoin(
-      input: { permissionJoin: { permissionNameId: 2000, userId: 2 } }
-    ) {
-      permissionName {
-        name
+  `mutation joinUsersToPermissionName {
+    updatePermissionName(
+      input: {
+        patch: {
+          permissionJoinsUsingId: {
+            create: [{ userId: 1 }, { userId: 2 }]
+          }
+        }
+        id: 3000
       }
-    }
-  }`,
-  `mutation userToPermissionNameJoin {
-    createPermissionJoin(
-      input: { permissionJoin: { permissionNameId: 2000, userId: 3 } }
-    ) {
-      permissionName {
-        name
-      }
-    }
-  }`,
-  `mutation userToPermissionNameJoin {
-    createPermissionJoin(
-      input: { permissionJoin: { permissionNameId: 2000, userId: 4 } }
-    ) {
-      permissionName {
-        name
-      }
-    }
-  }`,
-  `mutation userToPermissionNameJoin {
-    createPermissionJoin(
-      input: { permissionJoin: { permissionNameId: 3000, userId: 1 } }
-    ) {
-      permissionName {
-        name
-      }
-    }
-  }`,
-  `mutation userToPermissionNameJoin {
-    createPermissionJoin(
-      input: { permissionJoin: { permissionNameId: 3000, userId: 2 } }
     ) {
       permissionName {
         name


### PR DESCRIPTION
Had to refactor quite a bit to get this to work -- since most of the permissions were being created as part of the `createUser` section, they weren't available to add to templates that were inserted earlier.

So I've moved all policy creation and permissionName creation to their own files right at the beginning and the createUser mutations just link to existing permission names.

Added a new permission name "reviewReviewTest" with basicReview policy, linked to ReviewTest template and applies to all review stages and levels.

(Currently the new files are numbered 00A and 00B so I didn't have to change the names of other files. We'll renumber correctly at some point)