### PR TITLE
Add search attribute to Feature showcase

### DIFF
--- a/database/insertData/03_template_A_featureShowcase.js
+++ b/database/insertData/03_template_A_featureShowcase.js
@@ -376,6 +376,7 @@ exports.queries = [
                       parameters: {
                         label: "API Lookup: Choose a name from this list"
                         placeholder: "Select"
+                        search: true
                         options: {
                           operator: "API"
                           children: [


### PR DESCRIPTION
Tiny tweak to Feature Showcase template to add "search" parameter to one element, as implemented in front-end [PR#326](https://github.com/openmsupply/application-manager-web-app/pull/326).