### PR TITLE
Fix -- change type of review_status computed column

### DIFF
--- a/database/buildSchema/27_review.sql
+++ b/database/buildSchema/27_review.sql
@@ -16,7 +16,7 @@ RETURNS INT AS $$
 select level from review_assignment where id = $1 ;
 $$ LANGUAGE SQL IMMUTABLE;
 
--- FUNCTION to auto-add level to review
+-- FUNCTION to auto-add is_last_level to review
 CREATE or replace FUNCTION public.review_is_last_level(review_assignment_id int)
 RETURNS BOOLEAN AS $$
 select is_last_level from review_assignment where id = $1 ;

--- a/database/buildSchema/31_review_status_history.sql
+++ b/database/buildSchema/31_review_status_history.sql
@@ -31,7 +31,7 @@ EXECUTE FUNCTION public.review_status_history_is_current_update();
 
 -- Function to expose status name field on review table in GraphQL
 CREATE FUNCTION public.review_status(app public.review)
-RETURNS VARCHAR AS $$
-	SELECT "status"::VARCHAR FROM review_status_history 
+RETURNS public.review_status AS $$
+	SELECT "status" FROM review_status_history 
 	WHERE review_id = app.id and is_current = true
 $$ LANGUAGE sql STABLE;

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -10885,7 +10885,7 @@ export type Review = Node & {
   reviewStatusHistories: ReviewStatusHistoriesConnection;
   /** Reads and enables pagination through a set of `Notification`. */
   notifications: NotificationsConnection;
-  status?: Maybe<Scalars['String']>;
+  status?: Maybe<ReviewStatus>;
 };
 
 
@@ -11989,7 +11989,7 @@ export type ReviewFilter = {
   /** Filter by the object’s `isLastLevel` field. */
   isLastLevel?: Maybe<BooleanFilter>;
   /** Filter by the object’s `status` field. */
-  status?: Maybe<StringFilter>;
+  status?: Maybe<ReviewStatusFilter>;
   /** Filter by the object’s `reviewResponses` relation. */
   reviewResponses?: Maybe<ReviewToManyReviewResponseFilter>;
   /** Some related `reviewResponses` exist. */
@@ -20069,6 +20069,8 @@ export type ResolversTypes = {
   IntListFilter: IntListFilter;
   ReviewAssignmentToManyReviewFilter: ReviewAssignmentToManyReviewFilter;
   ReviewFilter: ReviewFilter;
+  ReviewStatusFilter: ReviewStatusFilter;
+  ReviewStatus: ReviewStatus;
   ReviewToManyReviewResponseFilter: ReviewToManyReviewResponseFilter;
   ReviewToManyReviewDecisionFilter: ReviewToManyReviewDecisionFilter;
   ReviewDecisionFilter: ReviewDecisionFilter;
@@ -20076,8 +20078,6 @@ export type ResolversTypes = {
   Decision: Decision;
   ReviewToManyReviewStatusHistoryFilter: ReviewToManyReviewStatusHistoryFilter;
   ReviewStatusHistoryFilter: ReviewStatusHistoryFilter;
-  ReviewStatusFilter: ReviewStatusFilter;
-  ReviewStatus: ReviewStatus;
   ReviewToManyNotificationFilter: ReviewToManyNotificationFilter;
   NotificationFilter: NotificationFilter;
   UserFilter: UserFilter;
@@ -21256,13 +21256,13 @@ export type ResolversParentTypes = {
   IntListFilter: IntListFilter;
   ReviewAssignmentToManyReviewFilter: ReviewAssignmentToManyReviewFilter;
   ReviewFilter: ReviewFilter;
+  ReviewStatusFilter: ReviewStatusFilter;
   ReviewToManyReviewResponseFilter: ReviewToManyReviewResponseFilter;
   ReviewToManyReviewDecisionFilter: ReviewToManyReviewDecisionFilter;
   ReviewDecisionFilter: ReviewDecisionFilter;
   DecisionFilter: DecisionFilter;
   ReviewToManyReviewStatusHistoryFilter: ReviewToManyReviewStatusHistoryFilter;
   ReviewStatusHistoryFilter: ReviewStatusHistoryFilter;
-  ReviewStatusFilter: ReviewStatusFilter;
   ReviewToManyNotificationFilter: ReviewToManyNotificationFilter;
   NotificationFilter: NotificationFilter;
   UserFilter: UserFilter;
@@ -23800,7 +23800,7 @@ export type ReviewResolvers<ContextType = any, ParentType extends ResolversParen
   reviewDecisions?: Resolver<ResolversTypes['ReviewDecisionsConnection'], ParentType, ContextType, RequireFields<ReviewReviewDecisionsArgs, 'orderBy'>>;
   reviewStatusHistories?: Resolver<ResolversTypes['ReviewStatusHistoriesConnection'], ParentType, ContextType, RequireFields<ReviewReviewStatusHistoriesArgs, 'orderBy'>>;
   notifications?: Resolver<ResolversTypes['NotificationsConnection'], ParentType, ContextType, RequireFields<ReviewNotificationsArgs, 'orderBy'>>;
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['ReviewStatus']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 


### PR DESCRIPTION
Small fix, noticed by @nmadruga in the front-end wondering why the GraphQL type for the `status` field on the review table (string) was different to the `status` field on review_status_history.

Turns out the function to generate the computed column on the review table was casting it to VARCHAR. This doesn't seem necessary, so have changed it to use the `review_status` enum type like the original field.

(Also, fixed another tiny typo while I was there)