### PR TITLE
#378F Review_status_history to expose the time_created of status in review table

### DIFF
--- a/database/buildSchema/27_review.sql
+++ b/database/buildSchema/27_review.sql
@@ -27,6 +27,7 @@ CREATE TABLE public.review (
 	id serial primary key,
 	review_assignment_id integer references public.review_assignment(id),
 	-- status via review_status_history
+	-- time_created viw review_status_history
 	trigger public.trigger,
 	application_id integer GENERATED ALWAYS AS (public.review_application_id(review_assignment_id)) STORED references public.application(id),
 	reviewer_id integer GENERATED ALWAYS AS (public.review_reviewer_id(review_assignment_id)) STORED references public.user(id),

--- a/database/buildSchema/31_review_status_history.sql
+++ b/database/buildSchema/31_review_status_history.sql
@@ -35,3 +35,10 @@ RETURNS public.review_status AS $$
 	SELECT "status" FROM review_status_history 
 	WHERE review_id = app.id and is_current = true
 $$ LANGUAGE sql STABLE;
+
+-- Function to expose time_create field on review table in GraphQL
+CREATE FUNCTION public.review_time_created(app public.review)
+RETURNS timestamptz AS $$
+	SELECT time_created FROM review_status_history 
+	WHERE review_id = app.id and is_current = true
+$$ LANGUAGE sql STABLE;

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -10904,6 +10904,7 @@ export type Review = Node & {
   /** Reads and enables pagination through a set of `Notification`. */
   notifications: NotificationsConnection;
   status?: Maybe<ReviewStatus>;
+  timeCreated?: Maybe<Scalars['Datetime']>;
 };
 
 
@@ -12140,6 +12141,8 @@ export type ReviewFilter = {
   isLastLevel?: Maybe<BooleanFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<ReviewStatusFilter>;
+  /** Filter by the object’s `timeCreated` field. */
+  timeCreated?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `reviewResponses` relation. */
   reviewResponses?: Maybe<ReviewToManyReviewResponseFilter>;
   /** Some related `reviewResponses` exist. */
@@ -24042,6 +24045,7 @@ export type ReviewResolvers<ContextType = any, ParentType extends ResolversParen
   reviewStatusHistories?: Resolver<ResolversTypes['ReviewStatusHistoriesConnection'], ParentType, ContextType, RequireFields<ReviewReviewStatusHistoriesArgs, 'orderBy'>>;
   notifications?: Resolver<ResolversTypes['NotificationsConnection'], ParentType, ContextType, RequireFields<ReviewNotificationsArgs, 'orderBy'>>;
   status?: Resolver<Maybe<ResolversTypes['ReviewStatus']>, ParentType, ContextType>;
+  timeCreated?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 


### PR DESCRIPTION
To be used combined with Front-end branch [PR#411](https://github.com/openmsupply/application-manager-web-app/pull/411)