### PR TITLE
#240 Evaluator -- handle unresolved objects

### DIFF
--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -143,7 +143,11 @@ For extracting values from local state objects (e.g. `user`, `organisation` or `
 
 The `evaluateExpression` function expects each expression to be passed along with _all_ objects that are required for evaluation in any descendant nodes. See **Usage** below for detailed overview of arguments.
 
-- Input: A single child node whose `value` is the name of the field whose value is to be extracted. Can be a nested property, written in dot notation (e.g. `questions.q2`) (but cannot yet get specific elements from arrays.)
+- Input:
+
+  - 1st child node returns the name of the field whose value is to be extracted. Can be a nested property, written in dot notation (e.g. `questions.q2`) (but cannot yet get specific elements from arrays.)
+  - 2nd (optional) node returns a Fallback value, to be returned if the property specified in the first node can't be resolved. Default is string "Can't resolve object", but could be useful to set to `null` in some cases.
+
 - Output: the value specified in `property` of any type.
 
 **Example**:

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -298,6 +298,22 @@ test('Test returning single application property, depth 2, no object index', () 
   })
 })
 
+test('Test unresolved object', () => {
+  return evaluateExpression(testData.objectPropertyUnresolved, {
+    objects: { application: testData.application },
+  }).then((result: any) => {
+    expect(result).toBe("Can't resolve object")
+  })
+})
+
+test('Test unresolved object with Null fallback', () => {
+  return evaluateExpression(testData.objectPropertyUnresolvedWithNullFallback, {
+    objects: { application: testData.application },
+  }).then((result: any) => {
+    expect(result).toBe(null)
+  })
+})
+
 // String substitution
 
 test('Simple string substitution', () => {

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -173,7 +173,9 @@ async function processGraphQL(queryArray: any[], connection: IGraphQLConnection)
     const [query, variableNames, variableValues, returnProperty] = assignChildNodesToQuery(
       queryArray
     )
+
     const variables = zipArraysToObject(variableNames, variableValues)
+
     const data = await graphQLquery(query, variables, connection)
     if (!data) throw new Error('GraphQL query problem')
     try {

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -86,9 +86,10 @@ export default async function evaluateExpression(
         try {
           const inputObject = params?.objects ? params.objects : {}
           const property = childrenResolved[0]
-          return extractProperty(inputObject, property)
+          const fallback = childrenResolved?.[1]
+          return extractProperty(inputObject, property, fallback)
         } catch {
-          throw new Error("Can't resolve object")
+          throw new Error('Problem evaluating object')
         }
 
       case 'stringSubstitution':
@@ -219,17 +220,19 @@ const zipArraysToObject = (variableNames: string[], variableValues: any[]) => {
 // Returns a specific property (e.g. application.name) from a nested Object
 const extractProperty = (
   data: BasicObject | BasicObject[],
-  node: string | string[]
+  node: string | string[],
+  fallback: any = "Can't resolve object"
 ): BasicObject | string | number | boolean | BasicObject[] => {
+  console.log('Fallback', fallback)
   const propertyPathArray = Array.isArray(node) ? node : node.split('.')
   // ie. "application.template.name" => ["applcation", "template", "name"]
   if (Array.isArray(data)) {
     // If an array, extract the property from *each item*
-    return data.map((item) => extractProperty(item, propertyPathArray))
+    return data.map((item) => extractProperty(item, propertyPathArray, fallback))
   }
   const currentProperty = propertyPathArray[0]
-  if (propertyPathArray.length === 1) return data[currentProperty]
-  else return extractProperty(data[currentProperty], propertyPathArray.slice(1))
+  if (propertyPathArray.length === 1) return data?.[currentProperty] || fallback
+  else return extractProperty(data[currentProperty], propertyPathArray.slice(1), fallback)
 }
 
 // If Object has only 1 property, return just the value of that property,

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -126,7 +126,7 @@ export default async function evaluateExpression(
           throw new Error('Problem with API call')
         }
         try {
-          return extractAndSimplify(data, returnProperty)
+          return extractAndSimplify(data, returnProperty, "API - Can't resolve property")
         } catch {
           throw new Error('Problem parsing requested node from API result')
         }
@@ -175,11 +175,12 @@ async function processGraphQL(queryArray: any[], connection: IGraphQLConnection)
     )
 
     const variables = zipArraysToObject(variableNames, variableValues)
-
+    console.log('query', query)
+    console.log('variables', variables)
     const data = await graphQLquery(query, variables, connection)
     if (!data) throw new Error('GraphQL query problem')
     try {
-      return extractAndSimplify(data, returnProperty)
+      return extractAndSimplify(data, returnProperty, "GraphQL - Can't resolve node")
     } catch (err) {
       throw new Error('GraphQL -- unable to retrieve node')
     }
@@ -190,9 +191,10 @@ async function processGraphQL(queryArray: any[], connection: IGraphQLConnection)
 
 const extractAndSimplify = (
   data: BasicObject | BasicObject[],
-  returnProperty: string | undefined
+  returnProperty: string | undefined,
+  fallback: any = "Can't resolve property"
 ) => {
-  const selectedProperty = returnProperty ? extractProperty(data, returnProperty) : data
+  const selectedProperty = returnProperty ? extractProperty(data, returnProperty, fallback) : data
   return Array.isArray(selectedProperty)
     ? selectedProperty.map((item) => simplifyObject(item))
     : returnProperty

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -173,10 +173,7 @@ async function processGraphQL(queryArray: any[], connection: IGraphQLConnection)
     const [query, variableNames, variableValues, returnProperty] = assignChildNodesToQuery(
       queryArray
     )
-
     const variables = zipArraysToObject(variableNames, variableValues)
-    console.log('query', query)
-    console.log('variables', variables)
     const data = await graphQLquery(query, variables, connection)
     if (!data) throw new Error('GraphQL query problem')
     try {
@@ -232,7 +229,8 @@ const extractProperty = (
     return data.map((item) => extractProperty(item, propertyPathArray, fallback))
   }
   const currentProperty = propertyPathArray[0]
-  if (propertyPathArray.length === 1) return data?.[currentProperty] || fallback
+  if (propertyPathArray.length === 1)
+    return data?.[currentProperty] != null ? data?.[currentProperty] : fallback
   else return extractProperty(data[currentProperty], propertyPathArray.slice(1), fallback)
 }
 

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -223,7 +223,6 @@ const extractProperty = (
   node: string | string[],
   fallback: any = "Can't resolve object"
 ): BasicObject | string | number | boolean | BasicObject[] => {
-  console.log('Fallback', fallback)
   const propertyPathArray = Array.isArray(node) ? node : node.split('.')
   // ie. "application.template.name" => ["applcation", "template", "name"]
   if (Array.isArray(data)) {

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -230,7 +230,7 @@ const extractProperty = (
   }
   const currentProperty = propertyPathArray[0]
   if (propertyPathArray.length === 1)
-    return data?.[currentProperty] != null ? data?.[currentProperty] : fallback
+    return data?.[currentProperty] != null ? data[currentProperty] : fallback
   else return extractProperty(data[currentProperty], propertyPathArray.slice(1), fallback)
 }
 

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -575,6 +575,16 @@ testData.singleApplicationProperty_depth2 = {
   children: ['application.questions.q2'],
 }
 
+testData.objectPropertyUnresolved = {
+  operator: 'objectProperties',
+  children: ['application.questions.q5'],
+}
+
+testData.objectPropertyUnresolvedWithNullFallback = {
+  operator: 'objectProperties',
+  children: ['application.querstions.q2', null],
+}
+
 // String substitution
 
 testData.stringSubstitutionSingle = {


### PR DESCRIPTION
Small improvement so that unresolved objects return a fallback value rather than throwing an error. Default fallback is "Can't resolve object", but can be useful to set to `null` in some case if you're not sure that the property will exist (Like for an API call, say).

Since GraphQL and API operators also use the same `extractProperty` method, this will work for those operators too -- I've added a specific fallback for them, mainly for debugging purposesd.

Also updated documentation, and added a couple of additional tests.

Bear in mind that whatever is returned by the node will be passed up back up the tree, so will be treated exactly like it would in normal javascript (e.g. "string" + null => "stringnull"). If you need to test if a property exists before returning something, you can use the `?` ternary operator. Use the expression-evaluator-gui if you want to see what happens with various expressions.