### PR TITLE
#464F-#465F-add-self-assignment-option-on-templatePermission

### DIFF
--- a/database/insertData/02_permission_names.js
+++ b/database/insertData/02_permission_names.js
@@ -220,4 +220,17 @@ exports.queries = [
       }
     }
   }`,
+  `mutation reviewSelfAssignable {
+    createPermissionName(
+      input: {
+        permissionName: { 
+          id: 10500
+          name: "reviewSelfAssignable",  permissionPolicyId: 3000 }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
 ]

--- a/database/insertData/03_template_D_basicReviewTesting.js
+++ b/database/insertData/03_template_D_basicReviewTesting.js
@@ -269,6 +269,7 @@ exports.queries = [
                 level: 1
                 restrictions: { templateSectionRestrictions: ["S2"] }
               }
+              { permissionNameId: 10500, restrictions: { canSelfAssign: true }, stageNumber:1, level: 1 }
               { id: 4003, permissionNameId: 6000, stageNumber: 2, level: 1 }
               { id: 4004, permissionNameId: 6001, stageNumber: 2, level: 2 }
               { id: 4005, permissionNameId: 7000, stageNumber: 3, level: 1 }

--- a/database/insertData/04_users.js
+++ b/database/insertData/04_users.js
@@ -12,6 +12,12 @@ exports.queries = [
           passwordHash: "$2a$10$dSDSYzTuuwJvEDp/tRsKXOV7LQc9Ue0gR8bctN4V7TcMRIfcCKhme"
           username: "nmadruga"
           firstName: "Nicole"
+          permissionJoinsUsingId: { 
+            create: [
+              # Self assign
+              { permissionNameId: 10500 }
+            ]
+          }
         }
       }
     ) {
@@ -28,6 +34,12 @@ exports.queries = [
           passwordHash: "$2a$10$3Z1cXVI.GzE9F2QYePzbMOg5CGtf6VnNKRiaiRGkzlBXJ0aiMN4JG"
           username: "carl"
           firstName: "Carl", lastName: "Smith"
+          permissionJoinsUsingId: { 
+            create: [
+              # Self assign
+              { permissionNameId: 10500 }
+            ]
+          }
         }
       }
     ) {
@@ -42,7 +54,14 @@ exports.queries = [
         user: { email: "andrei@sussol.net"
           passwordHash: "$2a$10$3Ufr.//hLoxp6BEEbFIq4u.zh435BNxNNLFEmJN74Ka/U5SMp0A2e"
           username: "andrei",
-          firstName: "Andrei" }
+          firstName: "Andrei" 
+          permissionJoinsUsingId: { 
+            create: [
+              # Self assign
+              { permissionNameId: 10500 }
+            ]
+          }
+        }
       }
     ) {
       user {

--- a/src/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
+++ b/src/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
@@ -45,6 +45,13 @@ module.exports['generateReviewAssignments'] = async function (input: any, DBConn
         ? restrictions?.templateSectionRestrictions
         : null
 
+      const canSelfAssign = restrictions?.canSelfAssign
+      // Automatic option for slef assignment if review is above level 1
+      const status =
+        canSelfAssign || nextReviewLevel > 1
+          ? AssignmentStatus.SELF_ASSIGN
+          : AssignmentStatus.AVAILABLE
+
       const userOrgKey = `${userId}_${orgId ? orgId : 0}`
       if (reviewAssignments[userOrgKey])
         reviewAssignments[userOrgKey].templateSectionRestrictions = mergeSectionRestrictions(
@@ -58,7 +65,7 @@ module.exports['generateReviewAssignments'] = async function (input: any, DBConn
           stageId,
           stageNumber,
           // TO-DO: allow STATUS to be configurable in template
-          status: nextReviewLevel === 1 ? AssignmentStatus.AVAILABLE : AssignmentStatus.SELF_ASSIGN,
+          status,
           applicationId,
           templateSectionRestrictions,
           level: nextReviewLevel,

--- a/src/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
+++ b/src/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
@@ -125,7 +125,7 @@ const generateNextReviewAssignments = async ({
       : null
 
     const status =
-      restrictions?.canSelfAssign || nextReviewLevel >= 1
+      restrictions?.canSelfAssign || nextReviewLevel > 1
         ? AssignmentStatus.SELF_ASSIGN
         : AssignmentStatus.AVAILABLE
 

--- a/src/plugins/action_generate_review_assignment_records/src/types.ts
+++ b/src/plugins/action_generate_review_assignment_records/src/types.ts
@@ -7,6 +7,7 @@ export enum AssignmentStatus {
 
 interface Restrictions {
   templateSectionRestrictions?: string[] | undefined
+  canSelfAssign?: boolean
 }
 
 export interface Reviewer {


### PR DESCRIPTION
Required for front end: #464-#465-Add-assignments-logic

### Changes

* Add canSelfAssign to templatePermission.restrictions (and make sure generated reviewAssignments are set to that if it exists)
* Add new permissionName (reviewSelfAssignable - 10500)
* Add template permission and user permissionJoin of permissionName for template testReview, as per below diagram (`under reviewSelfAssignable-10500` branch)

<img width="709" alt="Screen Shot 2021-03-25 at 12 37 42 PM" src="https://user-images.githubusercontent.com/26194949/112400234-c79ef580-8d6c-11eb-9072-a1b4523b8cad.png">
