### PR TITLE
#494F return sucess field in user-info endpoint

### DIFF
--- a/src/components/permissions/routes.ts
+++ b/src/components/permissions/routes.ts
@@ -71,7 +71,7 @@ const routeUserInfo = async (request: any, reply: any) => {
   const { userId, orgId, error } = await getTokenData(token)
   if (error) return reply.send({ success: false, message: error })
 
-  return reply.send(await getUserInfo({ userId, orgId }))
+  return reply.send({ success: true, ...(await getUserInfo({ userId, orgId })) })
 }
 
 const routeUpdateRowPolicies = async (request: any, reply: any) => {


### PR DESCRIPTION
In the process of trying to fix [front-end #494](https://github.com/openmsupply/application-manager-web-app/pull/553) I discovered that the 'user-info' endpoint was only returning a "success" field if it failed, not when `true`, which means the calling function couldn't check for success.

This rectifies that with a very small fix.