### PR TITLE
Fix nasty bug in postinstall

### DIFF
--- a/utils/pluginScripts/buildPlugin.js
+++ b/utils/pluginScripts/buildPlugin.js
@@ -11,6 +11,11 @@ const rootDirectory = __dirname + '/../..'
 
 const buildPlugin = async (pluginName) => {
   const pluginFolder = rootDirectory + '/plugins/' + pluginName
+  if (!fs.existsSync(path.join(fullPluginFolder, 'package.json'))) {
+    console.log('no package.json: ' + pluginName)
+    return
+  }
+
   const temporaryPluginBuildFolder = rootDirectory + '/temporaryPluginBuild'
 
   const yarnInstallAndPrep = async () => {

--- a/utils/pluginScripts/yarnInstallPlugins.js
+++ b/utils/pluginScripts/yarnInstallPlugins.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 const { exec } = require('child_process')
 // should run from root folder yarn scripts
 const pluginsFolder = './plugins/'
@@ -13,6 +14,10 @@ console.log('running yarn install for plugins')
 const command = 'yarn install'
 plugins.forEach((plugin) => {
   const { fullPluginFolder, pluginName } = plugin
+  if (!fs.existsSync(path.join(fullPluginFolder, 'package.json'))) {
+    console.log('no package.json: ' + pluginName)
+    return
+  }
   console.log('running yarn install for ' + pluginName + ' ... ')
 
   const options = { cwd: fullPluginFolder }


### PR DESCRIPTION
Getting freezes with postinstall (when plugins are installed), where plugin folder doesn't have package json (i.e. git ignored  node_modules folder exists, but no code). It also seems like cpu usage goes insane (without any log of what's happening, can hear my working overtime)

