### PR TITLE
#326 Fix to allow result of GraphQL operation to return Null instead of fallback

### DIFF
--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -622,6 +622,17 @@ test('Test GraphQL -- get country details by code from External Graphql API ', (
   })
 })
 
+test('Test GraphQL -- Check result of field can be null', () => {
+  return evaluateExpression(testData.GraphQL_CheckDefaultResultIsNull, {
+    graphQLConnection: {
+      fetch: fetch,
+      endpoint: graphQLendpoint,
+    },
+  }).then((result: any) => {
+    expect(result).toBe(null)
+  })
+})
+
 // TO-DO: Test with multiple variables and dynamic values
 
 // More complex combinations

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -251,7 +251,7 @@ const extractProperty = (
   }
   const currentProperty = propertyPathArray[0]
   if (propertyPathArray.length === 1)
-    return data[currentProperty] === undefined ? fallback : data[currentProperty]
+    return data?.[currentProperty] === undefined ? fallback : data[currentProperty]
   else return extractProperty(data[currentProperty], propertyPathArray.slice(1), fallback)
 }
 

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -251,7 +251,7 @@ const extractProperty = (
   }
   const currentProperty = propertyPathArray[0]
   if (propertyPathArray.length === 1)
-    return !!data[currentProperty] ? fallback : data[currentProperty]
+    return data[currentProperty] === undefined ? fallback : data[currentProperty]
   else return extractProperty(data[currentProperty], propertyPathArray.slice(1), fallback)
 }
 

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -207,11 +207,12 @@ const extractAndSimplify = (
   fallback: any = "Can't resolve property"
 ) => {
   const selectedProperty = returnProperty ? extractProperty(data, returnProperty, fallback) : data
-  return Array.isArray(selectedProperty)
-    ? selectedProperty.map((item) => simplifyObject(item))
-    : returnProperty
-    ? simplifyObject(selectedProperty)
-    : selectedProperty
+  if (Array.isArray(selectedProperty)) return selectedProperty.map((item) => simplifyObject(item))
+  if (returnProperty) {
+    if (selectedProperty === null) return null // GraphQL field can return null as valid result
+    return simplifyObject(selectedProperty)
+  }
+  return selectedProperty
 }
 
 const assignChildNodesToQuery = (childNodes: any[]) => {
@@ -250,7 +251,7 @@ const extractProperty = (
   }
   const currentProperty = propertyPathArray[0]
   if (propertyPathArray.length === 1)
-    return data?.[currentProperty] != null ? data[currentProperty] : fallback
+    return !!data[currentProperty] ? fallback : data[currentProperty]
   else return extractProperty(data[currentProperty], propertyPathArray.slice(1), fallback)
 }
 

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -907,6 +907,16 @@ testData.GraphQL_GetCountryByCode_ExternalAPI = {
   ],
 }
 
+testData.GraphQL_CheckDefaultResultIsNull = {
+  operator: 'graphQL',
+  children: [
+    `query country ($code: ID = "") { country (code: $code) { name } }`,
+    'https://countries.trevorblades.com',
+    [],
+    'country',
+  ],
+}
+
 // More complex combinations
 
 testData.concatFirstAndLastNames = {


### PR DESCRIPTION
Fixes #326 

Another quick fix, needed to get proper result for when the query results on `null` as "no results" for the given input.