### PR TITLE
#313 Action plugin file path fix

### DIFF
--- a/src/components/registerPlugins.ts
+++ b/src/components/registerPlugins.ts
@@ -42,7 +42,6 @@ export default async function registerPlugins() {
         console.log('Failed to parse plugin.json in: ' + pluginPath)
         throw e
       }
-      // console.log('pluginDirName', pluginDirName)
       const pluginObject = {
         ...pluginJson,
         path: getPluginIndexPath(pluginPath),

--- a/src/components/registerPlugins.ts
+++ b/src/components/registerPlugins.ts
@@ -13,21 +13,20 @@ import * as config from '../config.json'
 import DBConnect from './databaseConnect'
 import { ActionPlugin } from '../types'
 
-const pluginsFolder = path.join(getAppEntryPointDir(), config.pluginsFolder)
+const pluginsFolderFull = path.join(getAppEntryPointDir(), config.pluginsFolder)
+const pluginsFolder = config.pluginsFolder
 const pluginJsonFilename = 'plugin.json'
 const getPluginIndexPath = (pluginFolderPath: string) =>
   fs.existsSync(path.join(pluginFolderPath, 'src', 'index.js'))
-    ? path.join(pluginFolderPath, 'src', 'index.js') // in production use index.js
-    : path.join(pluginFolderPath, 'src', 'index.ts') // otherwoise use index.ts
+    ? path.join(pluginsFolder, 'src', 'index.js') // in production use index.js
+    : path.join(pluginsFolder, 'src', 'index.ts') // otherwise use index.ts
 
 export default async function registerPlugins() {
   // Load plugin info from files
   console.log('Scanning plugins folder...')
   const plugins = fs
-    .readdirSync(pluginsFolder)
-    .map((pluginFolder) => {
-      return path.join(pluginsFolder, pluginFolder)
-    })
+    .readdirSync(pluginsFolderFull)
+    .map((pluginFolder) => path.join(pluginsFolderFull, pluginFolder))
     .filter((pluginPath) => fs.statSync(pluginPath).isDirectory())
     .filter((pluginPath) => fs.existsSync(path.join(pluginPath, pluginJsonFilename)))
     .map((pluginPath) => {
@@ -43,6 +42,7 @@ export default async function registerPlugins() {
         ...pluginJson,
         path: getPluginIndexPath(pluginPath),
       }
+      console.log('pluginPath', pluginPath)
       return pluginObject
     })
 

--- a/src/components/registerPlugins.ts
+++ b/src/components/registerPlugins.ts
@@ -17,32 +17,36 @@ const pluginsFolderFull = path.join(getAppEntryPointDir(), config.pluginsFolder)
 const pluginsFolder = config.pluginsFolder
 const pluginJsonFilename = 'plugin.json'
 const getPluginIndexPath = (pluginFolderPath: string) =>
-  fs.existsSync(path.join(pluginFolderPath, 'src', 'index.js'))
-    ? path.join(pluginsFolder, 'src', 'index.js') // in production use index.js
-    : path.join(pluginsFolder, 'src', 'index.ts') // otherwise use index.ts
+  fs.existsSync(path.join(pluginsFolderFull, pluginFolderPath, 'src', 'index.js'))
+    ? path.join(pluginsFolder, pluginFolderPath, 'src', 'index.js') // in production use index.js
+    : path.join(pluginsFolder, pluginFolderPath, 'src', 'index.ts') // otherwise use index.ts
 
 export default async function registerPlugins() {
   // Load plugin info from files
   console.log('Scanning plugins folder...')
   const plugins = fs
     .readdirSync(pluginsFolderFull)
-    .map((pluginFolder) => path.join(pluginsFolderFull, pluginFolder))
-    .filter((pluginPath) => fs.statSync(pluginPath).isDirectory())
-    .filter((pluginPath) => fs.existsSync(path.join(pluginPath, pluginJsonFilename)))
+    .filter((pluginPath) => fs.statSync(path.join(pluginsFolderFull, pluginPath)).isDirectory())
+    .filter((pluginPath) =>
+      fs.existsSync(path.join(pluginsFolderFull, pluginPath, pluginJsonFilename))
+    )
     .map((pluginPath) => {
-      const pluginJsonContent = fs.readFileSync(path.join(pluginPath, pluginJsonFilename), 'utf8')
+      const pluginJsonContent = fs.readFileSync(
+        path.join(pluginsFolderFull, pluginPath, pluginJsonFilename),
+        'utf8'
+      )
       let pluginJson
       try {
         pluginJson = JSON.parse(pluginJsonContent)
       } catch (e) {
-        console.log('Failed to prase plugin.json in: ' + pluginPath)
+        console.log('Failed to parse plugin.json in: ' + pluginPath)
         throw e
       }
+      // console.log('pluginDirName', pluginDirName)
       const pluginObject = {
         ...pluginJson,
         path: getPluginIndexPath(pluginPath),
       }
-      console.log('pluginPath', pluginPath)
       return pluginObject
     })
 

--- a/src/components/triggersAndActions.ts
+++ b/src/components/triggersAndActions.ts
@@ -26,9 +26,7 @@ export const loadActions = async function (actionLibrary: ActionLibrary) {
 
     result.forEach((row) => {
       // This should import action from index.js (entry point of plugin)
-      console.log('row', row)
       actionLibrary[row.code] = require(path.join(getAppEntryPointDir(), row.path)).action
-      // actionLibrary[row.code] = require(row.path).action
       console.log('Action loaded: ' + row.code)
     })
 

--- a/src/components/triggersAndActions.ts
+++ b/src/components/triggersAndActions.ts
@@ -11,6 +11,8 @@ import DBConnect from './databaseConnect'
 import { actionLibrary } from './pluginsConnect'
 import { BasicObject, IParameters, IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
 import { getApplicationData } from './getApplicationData'
+import { getAppEntryPointDir } from './utilityFunctions'
+import path from 'path'
 import { ActionQueueStatus, TriggerQueueStatus } from '../generated/graphql'
 
 const schedule = require('node-schedule')
@@ -24,7 +26,9 @@ export const loadActions = async function (actionLibrary: ActionLibrary) {
 
     result.forEach((row) => {
       // This should import action from index.js (entry point of plugin)
-      actionLibrary[row.code] = require(row.path).action
+      console.log('row', row)
+      actionLibrary[row.code] = require(path.join(getAppEntryPointDir(), row.path)).action
+      // actionLibrary[row.code] = require(row.path).action
       console.log('Action loaded: ' + row.code)
     })
 


### PR DESCRIPTION
Change registerPlugins.ts to store the action path relative to the project root, not the absolute path. Full path is reconstructed (using `getAppEntryPointDir()`) as actions are loaded in triggersAndActions.ts