### PR TITLE
#341 Server returns templatePermissions restricted by Org

### DIFF
--- a/src/components/permissions/loginHelpers.ts
+++ b/src/components/permissions/loginHelpers.ts
@@ -52,7 +52,7 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
       return { orgId, orgName, userRole, registration, address, logoUrl }
     })
 
-  const templatePermissionRows = await databaseConnect.getUserTemplatePermissions(newUsername)
+  const templatePermissionRows = await databaseConnect.getUserTemplatePermissions(newUsername, orgId || null)
 
   const selectedOrg = orgId ? orgList.filter((org) => org.orgId === orgId) : undefined
 

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -575,10 +575,15 @@ class PostgresDB {
     }
   }
 
-  public getUserTemplatePermissions = async (username: string) => {
-    const text = 'select * from permissions_all where username = $1'
+  public getUserTemplatePermissions = async (username: string, orgId: number |null) => {
+    const text = `SELECT * FROM permissions_all
+      WHERE username = $1
+      AND "orgId" ${orgId === null ? "IS NULL" : "= $2"}
+      `
+      const values:(string|number)[] = [username]
+      if (orgId) values.push(orgId)
     try {
-      const result = await this.query({ text, values: [username] })
+      const result = await this.query({ text, values })
       return result.rows
     } catch (err) {
       console.log(err.message)


### PR DESCRIPTION
Postman collection for testing all three endpoints (/login, /login-org, /user-info):

[Login with Org.postman_collection.json.zip](https://github.com/openmsupply/application-manager-server/files/6449538/Login.with.Org.postman_collection.json.zip)

Initially, using "login" as "carl", it should return all template permissions with a "NULL" org. The "/login-org" and "/user-info" should return empty templatePermissions, as user "carl" has no permissions associated with orgs.

Now add a permission linking user AND org to a permissionName:
```
mutation addPermission {
  createPermissionJoin(
    input: {
      permissionJoin: {
        permissionNameToPermissionNameId: {
          connectByName: { name: "applyGeneral" }
        }
        userToUserId: { connectByUsername: { username: "carl" } }
        organisationId: 2
      }
    }
  ) {
    clientMutationId
  }
}
```

Now when you call the "/login-org" and "/user-info" , user "carl" with orgId = 2 should have "applyGeneral" permissions for associated templates