### PR TITLE
#352 Graphile user can insert data

### DIFF
--- a/database/buildSchema/35_row_level_policy_related.sql
+++ b/database/buildSchema/35_row_level_policy_related.sql
@@ -1,6 +1,7 @@
 -- Row level policy
-ALTER TABLE public.application ENABLE ROW LEVEL SECURITY;
-
+-- ALTER TABLE public.application ENABLE ROW LEVEL SECURITY;
+-- ALTER TABLE public.review ENABLE ROW LEVEL SECURITY;
+-- ALTER TABLE public.review_assignment ENABLE ROW LEVEL SECURITY;
 CREATE ROLE graphile_user WITH NOLOGIN;
 
 ALTER ROLE graphile_user WITH LOGIN;

--- a/database/buildSchema/40_graphile_user.sql
+++ b/database/buildSchema/40_graphile_user.sql
@@ -1,7 +1,3 @@
--- Row level policy
--- ALTER TABLE public.application ENABLE ROW LEVEL SECURITY;
--- ALTER TABLE public.review ENABLE ROW LEVEL SECURITY;
--- ALTER TABLE public.review_assignment ENABLE ROW LEVEL SECURITY;
 CREATE ROLE graphile_user WITH NOLOGIN;
 
 ALTER ROLE graphile_user WITH LOGIN;

--- a/database/insert_data.sh
+++ b/database/insert_data.sh
@@ -9,8 +9,8 @@ PID=$!
 wait $PID
 
 # Turn on Row-level Security
-# echo -e "\nEnabling Row-level Security..."
-# psql -U postgres -q -b -d tmf_app_manager -f "./database/turn_on_row_level_security.sql"
+echo -e "\nEnabling Row-level Security..."
+psql -U postgres -q -b -d tmf_app_manager -f "./database/turn_on_row_level_security.sql"
 # >&/dev/null #suppress output for this command
 
 node ./database/updateRowPolicies.js --from_insert_data.sh &

--- a/database/insert_data.sh
+++ b/database/insert_data.sh
@@ -11,7 +11,6 @@ wait $PID
 # Turn on Row-level Security
 echo -e "\nEnabling Row-level Security..."
 psql -U postgres -q -b -d tmf_app_manager -f "./database/turn_on_row_level_security.sql"
-# >&/dev/null #suppress output for this command
 
 node ./database/updateRowPolicies.js --from_insert_data.sh &
 

--- a/database/insert_data.sh
+++ b/database/insert_data.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-#insert data from 
-echo "\nInserting data..."
+#insert data from
+echo -e "\nInserting data..."
 
 node ./database/insertData.js --from_insert_data.sh &
 
 # Makes script wait until async node script has completed
 PID=$!
 wait $PID
+
+# Turn on Row-level Security
+# echo -e "\nEnabling Row-level Security..."
+# psql -U postgres -q -b -d tmf_app_manager -f "./database/turn_on_row_level_security.sql"
+# >&/dev/null #suppress output for this command
 
 node ./database/updateRowPolicies.js --from_insert_data.sh &
 

--- a/database/post_data_insert.sh
+++ b/database/post_data_insert.sh
@@ -3,7 +3,7 @@
 PID=$!
 wait $PID
 
-echo "\nGenerating types file..."
+echo -e "\nGenerating types file..."
 yarn generate
 
 # This forces server to restart

--- a/database/turn_on_row_level_security.sql
+++ b/database/turn_on_row_level_security.sql
@@ -1,0 +1,8 @@
+-- Connect to database first:
+\c tmf_app_manager
+ALTER TABLE public.application ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.review ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.review_assignment ENABLE ROW LEVEL SECURITY;
+


### PR DESCRIPTION
Came up with a simpler way for insertData to work while PostGraphile is logged in as `graphile_user` (i.e. row-level security enforced)

Basically, I just moved the commands to turn on ROW LEVEL SECURITY out of the main "buildSchema" folder, and now they run separately _after_  insertData has finished.