### PR TITLE
#741F create locked review when assignment is locked

### DIFF
--- a/database/insertData/core_mutations.js
+++ b/database/insertData/core_mutations.js
@@ -46,15 +46,9 @@ exports.coreActions = `
       trigger: ON_REVIEW_CREATE
       sequence: 2
       condition: {
-        operator: "="
+        operator: "objectProperties"
         children: [
-          {
-            operator: "objectProperties"
-            children: [
-              "applicationData.reviewData.reviewAssignment.isLocked"
-            ]
-          }
-          "true"
+          "applicationData.reviewData.reviewAssignment.isLocked"
         ]
       }
       parameterQueries: {

--- a/database/insertData/core_mutations.js
+++ b/database/insertData/core_mutations.js
@@ -31,7 +31,8 @@ exports.coreActions = `
       }
     }
     # ON_REVIEW_CREATE
-    # change status to DRAFT
+    # 1 - change status to DRAFT
+    # 2 - lock review if assignment is locked
     {
         actionCode: "changeStatus"
         trigger: ON_REVIEW_CREATE
@@ -40,6 +41,26 @@ exports.coreActions = `
           newStatus: "DRAFT"
         }
     }
+    {
+      actionCode: "changeStatus"
+      trigger: ON_REVIEW_CREATE
+      sequence: 2
+      condition: {
+        operator: "="
+        children: [
+          {
+            operator: "objectProperties"
+            children: [
+              "applicationData.reviewData.reviewAssignment.isLocked"
+            ]
+          }
+          "true"
+        ]
+      }
+      parameterQueries: {
+        newStatus: "LOCKED"
+      }
+  }
     # ON_APPLICATION_SUBMIT
     # 1 - change status to SUBMITTED
     # 2 - trim responses

--- a/src/components/graphQLConnect.ts
+++ b/src/components/graphQLConnect.ts
@@ -40,6 +40,9 @@ class GraphQLdb {
               decision
               comment
           }
+          reviewAssignment {
+            isLocked
+          }
         }
       }
       `,


### PR DESCRIPTION
Back-end for issue #741

### Front-end PR:
[#741](https://github.com/openmsupply/application-manager-web-app/pull/746)

### Branched of PR:
[#364](https://github.com/openmsupply/application-manager-server/pull/375) 

### Changes
- Add sequence action ON_REVIEW_START to set `review.status` as LOCKED when `reviewAssignment.isLocked` is true
- Needed to add `reviewAssignment.isLocked` to get returned on `getApplicationData` to show on actions
