### PR TITLE
#750F #751F Ingredients list updates

### DIFF
--- a/database/insertData/03_template_A_featureShowcase.js
+++ b/database/insertData/03_template_A_featureShowcase.js
@@ -1003,7 +1003,7 @@ exports.queries = [
                       parameters: {
                         label: "Ingredients list"
                         createModalButtonText: "Add ingredient"
-                        modalText: "Please enter details for **one** ingredient"
+                        modalText: "## Ingredient item \\n\\nPlease enter details for **one** ingredient"
                         displayType: {
                           operator: "objectProperties"
                           children: ["responses.listDisplay.text"]
@@ -1032,19 +1032,6 @@ exports.queries = [
                           }
                           {
                             code: "LB3"
-                            title: "Included"
-                            elementTypePluginCode: "checkbox"
-                            category: QUESTION
-                            parameters: {
-                              label: "Substance present in end product"
-                              checkboxes: [ {
-                                label: "Yes"
-                                textNegative: "No"
-                              } ]
-                            }
-                          }
-                          {
-                            code: "LB4"
                             title: "Quantity"
                             elementTypePluginCode: "shortText"
                             category: QUESTION
@@ -1064,10 +1051,11 @@ exports.queries = [
                             parameters: {
                               label: "Quantity"
                               description: "Enter a number and select units below"
+                              maxWidth: 130
                             }
                           }
                           {
-                            code: "LB5"
+                            code: "LB4"
                             title: "Unit"
                             elementTypePluginCode: "radioChoice"
                             category: QUESTION
@@ -1078,7 +1066,7 @@ exports.queries = [
                             }
                           }
                           {
-                            code: "LB6"
+                            code: "LB5"
                             title: "Type"
                             elementTypePluginCode: "dropdownChoice"
                             category: QUESTION
@@ -1086,6 +1074,17 @@ exports.queries = [
                               label: "Type"
                               options: ["Active", "Inactive"]
                               default: 0
+                            }
+                          }
+                          {
+                            code: "LB6"
+                            title: "Included"
+                            elementTypePluginCode: "radioChoice"
+                            category: QUESTION
+                            parameters: {
+                              label: "Substance present in end product"
+                              options: [ "Yes", "No" ]
+                              layout: "inline"
                             }
                           }
                         ]


### PR DESCRIPTION
Back-end changes for [front-end PR #755](https://github.com/openmsupply/application-manager-web-app/pull/755)

Changes the Ingredients list demo in FeatureShowcase to more closely reflect the latest Miro designs for Ingredients list, including inline radio buttons and limited-width text inputs.