### PR TITLE
#761F generic default value handling to work for all plugins

### DIFF
--- a/database/buildSchema/14_template_element.sql
+++ b/database/buildSchema/14_template_element.sql
@@ -32,6 +32,7 @@ CREATE TABLE public.template_element (
     is_required jsonb DEFAULT 'true' ::jsonb,
     is_editable jsonb DEFAULT 'true' ::jsonb,
     validation jsonb DEFAULT 'true' ::jsonb,
+    default_value jsonb,
     validation_message varchar,
     help_text varchar,
     parameters jsonb,

--- a/database/insertData/_common/03_template_G_userEdit.js
+++ b/database/insertData/_common/03_template_G_userEdit.js
@@ -46,12 +46,21 @@ exports.queries = [
                         ]
                       }
                       validationMessage: "First name must not be blank"
+                      defaultValue: {
+                        operator: "buildObject"
+                        properties: [
+                          {
+                            key: "text"
+                            value: {
+                              operator: "objectProperties"
+                              children: ["currentUser.firstName"]
+                            }
+                          }
+                        ]
+                      }
+      
                       parameters: {
                         label: "First Name"
-                        default: {
-                          operator: "objectProperties"
-                          children: ["currentUser.firstName"]
-                        }
                       }
                     }
                     {
@@ -60,12 +69,20 @@ exports.queries = [
                       title: "Last Name"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      defaultValue: {
+                        operator: "buildObject"
+                        properties: [
+                          {
+                            key: "text"
+                            value: {
+                              operator: "objectProperties"
+                              children: ["currentUser.lastName"]
+                            }
+                          }
+                        ]
+                      }
                       parameters: {
                         label: "Last Name"
-                        default: {
-                          operator: "objectProperties"
-                          children: ["currentUser.lastName"]
-                        }
                       }
                     }
                     {
@@ -74,6 +91,18 @@ exports.queries = [
                       title: "Username"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      defaultValue: {
+                        operator: "buildObject"
+                        properties: [
+                          {
+                            key: "text"
+                            value: {
+                              operator: "objectProperties"
+                              children: ["currentUser.username"]
+                            }
+                          }
+                        ]
+                      }
                       validation: {
                         # Must be unique OR same as current
                         operator: "OR"
@@ -109,10 +138,6 @@ exports.queries = [
                       validationMessage: "Username must be unique"
                       parameters: {
                         label: "Select a username"
-                        default: {
-                          operator: "objectProperties"
-                          children: ["currentUser.username"]
-                        }
                       }
                     }
                     {
@@ -121,6 +146,18 @@ exports.queries = [
                       title: "Email"
                       elementTypePluginCode: "shortText"
                       category: QUESTION
+                      defaultValue: {
+                        operator: "buildObject"
+                        properties: [
+                          {
+                            key: "text"
+                            value: {
+                              operator: "objectProperties"
+                              children: ["currentUser.email"]
+                            }
+                          }
+                        ]
+                      }
                       validation: {
                         operator: "REGEX"
                         children: [
@@ -136,10 +173,6 @@ exports.queries = [
                       validationMessage: "Not a valid email address"
                       parameters: {
                         label: "Email"
-                        default: {
-                          operator: "objectProperties"
-                          children: ["currentUser.email"]
-                        }
                       }
                     }
                     {
@@ -213,9 +246,16 @@ exports.queries = [
                       elementTypePluginCode: "password"
                       category: QUESTION
                       visibilityCondition: {
-                        operator: "objectProperties"
-                        children: ["responses.currentPassword.isValid"]
+                        operator: "="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["responses.currentPassword.isValid", false]
+                          }
+                          true
+                        ]
                       }
+                      
                       parameters: {
                         label: "New Password"
                         description: "Please select a new password"

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -50,6 +50,7 @@ For more complex lookups, we would hide the complexity from the user in the Temp
   - [graphQL](#graphql)
   - [GET](#get)
   - [POST](#post)
+  - [buildObject](#buildObject)
 - [Usage](#usage)
 - [Examples](#examples)
 - [To Do](#to-do)

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -355,7 +355,7 @@ properties: [{
 ]
 ```
 
-- Output evaluated object, empty object by default. If value or key evaluates to undefined it wont' be present in the output
+- Output evaluated object, empty object by default. If value or key evaluates to `undefined`, the property will be omitted from the output.
 
 **See test in {evaluator module}/src/resolvers/buildObject.test.ts for further examples**
 

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -386,19 +386,21 @@ Input
 ```
 {
   operator: "buildObject",
-  properties: [{
-    key: "someKey",
-    value: "someValue"
-  },{
-    key: {
-      operator: "+",
-      children: ["evaluted", "key"]
+  properties: [
+    {
+      key: "someKey",
+      value: "someValue"
     },
-    value: {
-      operator: "AND",
-      children: [true, false]
-     },
-   }
+    {
+      key: {
+        operator: "+",
+        children: ["evaluated", "key"]
+      },
+      value: {
+        operator: "AND",
+        children: [true, false]
+       },
+     }
   ]
 }
 ```

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -350,7 +350,9 @@ Using custom object shape for configuration vs children array
 properties: [{
   key: {evaluation or value}
   value: {evaluation or value}
-}, {more key values}
+},
+  ... { more key-values }
+]
 ```
 
 - Output evaluated object, empty object by default. If value or key evaluates to undefined it wont' be present in the output

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -337,6 +337,78 @@ This expression queries our `/login` endpoint to check a user's credentials, and
 }
 ```
 
+## buildObject
+
+Build a key/value object with evaluatable keys and values
+
+Using custom object shape for configuration vs children array
+
+- Input format
+
+```
+properites: [{
+  key: {evaluation or value}
+  value: {evaluation or value}
+}, {more key values}
+```
+
+- Output evaluated object, empty object by default. If value or key evaluates to undefined it wont' be present in the output
+
+**See test in {evaluator module}/src/resolvers/buildObject.test.ts for further examples**
+
+**Example**:
+
+Input
+
+```
+{
+  operator: "buildObject",
+  properties: [{
+    key: "someKey",
+    value: true
+  }]
+}
+```
+
+Output
+
+```
+{
+  "someKey": true
+}
+```
+
+Input
+
+```
+{
+  operator: "buildObject",
+  properties: [{
+    key: "someKey",
+    value: "someValue"
+  },{
+    key: {
+      operator: "+",
+      children: ["evaluted", "key"]
+    },
+    value: {
+      operator: "AND",
+      children: [true, false]
+     },
+   }
+  ]
+}
+```
+
+Output
+
+```
+{
+  "someKey": "someValue",
+  "evaluatedKey": false
+}
+```
+
 # Usage
 
 The query evaluator is implemented in the `evaluateExpression` function:

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -347,7 +347,7 @@ Using custom object shape for configuration vs children array
 - Input format
 
 ```
-properites: [{
+properties: [{
   key: {evaluation or value}
   value: {evaluation or value}
 }, {more key values}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.0.0",
     "@openmsupply/deep-comparison": "^1.0.1",
-    "@openmsupply/expression-evaluator": "^1.7.0",
+    "@openmsupply/expression-evaluator": "^1.8.0",
     "@types/jsonwebtoken": "^8.5.0",
     "bcrypt": "^5.0.0",
     "comment-json": "^4.1.0",

--- a/src/components/triggersAndActions.ts
+++ b/src/components/triggersAndActions.ts
@@ -5,12 +5,15 @@ import {
   ActionPayload,
   ActionSequential,
   ActionQueueExecutePayload,
-  EvaluatorNode,
 } from '../types'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 import DBConnect from './databaseConnect'
 import { actionLibrary } from './pluginsConnect'
-import { BasicObject, IParameters } from '@openmsupply/expression-evaluator/lib/types'
+import {
+  BasicObject,
+  EvaluatorNode,
+  IParameters,
+} from '@openmsupply/expression-evaluator/lib/types'
 import { getApplicationData } from './getApplicationData'
 import { getAppEntryPointDir } from './utilityFunctions'
 import path from 'path'

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1919,6 +1919,7 @@ export type ApplicationResponseTemplateElementIdFkeyTemplateElementCreateInput =
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -16998,6 +16999,7 @@ export type ReviewQuestionAssignmentTemplateElementIdFkeyTemplateElementCreateIn
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -17872,6 +17874,7 @@ export type ReviewResponseTemplateElementIdFkeyTemplateElementCreateInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -19329,6 +19332,7 @@ export type TemplateElement = Node & {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -19437,6 +19441,8 @@ export type TemplateElementCondition = {
   isEditable?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `validation` field. */
   validation?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `defaultValue` field. */
+  defaultValue?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `validationMessage` field. */
   validationMessage?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `helpText` field. */
@@ -19471,6 +19477,8 @@ export type TemplateElementFilter = {
   isEditable?: Maybe<JsonFilter>;
   /** Filter by the object’s `validation` field. */
   validation?: Maybe<JsonFilter>;
+  /** Filter by the object’s `defaultValue` field. */
+  defaultValue?: Maybe<JsonFilter>;
   /** Filter by the object’s `validationMessage` field. */
   validationMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `helpText` field. */
@@ -19516,6 +19524,7 @@ export type TemplateElementInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -19643,6 +19652,7 @@ export type TemplateElementPatch = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -19722,6 +19732,7 @@ export type TemplateElementSectionIdFkeyTemplateElementCreateInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -19778,6 +19789,8 @@ export enum TemplateElementsOrderBy {
   IsEditableDesc = 'IS_EDITABLE_DESC',
   ValidationAsc = 'VALIDATION_ASC',
   ValidationDesc = 'VALIDATION_DESC',
+  DefaultValueAsc = 'DEFAULT_VALUE_ASC',
+  DefaultValueDesc = 'DEFAULT_VALUE_DESC',
   ValidationMessageAsc = 'VALIDATION_MESSAGE_ASC',
   ValidationMessageDesc = 'VALIDATION_MESSAGE_DESC',
   HelpTextAsc = 'HELP_TEXT_ASC',
@@ -25130,6 +25143,7 @@ export type UpdateTemplateElementOnApplicationResponseForApplicationResponseTemp
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -25153,6 +25167,7 @@ export type UpdateTemplateElementOnReviewQuestionAssignmentForReviewQuestionAssi
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -25176,6 +25191,7 @@ export type UpdateTemplateElementOnReviewResponseForReviewResponseTemplateElemen
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -25198,6 +25214,7 @@ export type UpdateTemplateElementOnTemplateElementForTemplateElementSectionIdFke
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -32907,6 +32924,7 @@ export type TemplateElementResolvers<ContextType = any, ParentType extends Resol
   isRequired?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   isEditable?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   validation?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  defaultValue?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   validationMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   helpText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   parameters?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;

--- a/src/modules/expression-evaluator/expression-evaluate-gui/package.json
+++ b/src/modules/expression-evaluator/expression-evaluate-gui/package.json
@@ -17,7 +17,7 @@
     "react-scripts": "3.4.3"
   },
   "scripts": {
-    "start": "rimraf ./src/expression-evaluator && mkdir ./src/expression-evaluator && cp ../src/evaluateExpression.ts ../src/types.ts ./src/expression-evaluator && concurrently --kill-others-on-fail \"yarn serve\" \"PORT=3005 react-scripts start\"",
+    "start": "rimraf ./src/expression-evaluator && mkdir ./src/expression-evaluator && cp -R ../src/* ./src/expression-evaluator && concurrently --kill-others-on-fail \"yarn serve\" \"PORT=3005 react-scripts start\"",
     "build": "react-scripts build",
     "serve": "node ./src/express/server",
     "eject": "react-scripts eject"

--- a/src/modules/expression-evaluator/package.json
+++ b/src/modules/expression-evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmsupply/expression-evaluator",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Module to evaluate dynamic expressions for the openMsupply Application Manager project",
   "main": "lib/evaluateExpression.js",
   "types": "lib/evaluateExpression.d.ts",

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -314,6 +314,14 @@ test('Test unresolved object with Null fallback', () => {
   })
 })
 
+test('Test unresolved object with Null fallback, deep query', () => {
+  return evaluateExpression(testData.objectPropertyUnresolvedDeepWithNullFallback, {
+    objects: { application: testData.application },
+  }).then((result: any) => {
+    expect(result).toBe(null)
+  })
+})
+
 // String substitution
 
 test('Simple string substitution', () => {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -603,6 +603,11 @@ testData.objectPropertyUnresolvedWithNullFallback = {
   children: ['application.querstions.q2', null],
 }
 
+testData.objectPropertyUnresolvedDeepWithNullFallback = {
+  operator: 'objectProperties',
+  children: ['application.querstions.q2.something.0.else.more', null],
+}
+
 // String substitution
 
 testData.stringSubstitutionSingle = {

--- a/src/modules/expression-evaluator/src/resolvers/buildObject.test.ts
+++ b/src/modules/expression-evaluator/src/resolvers/buildObject.test.ts
@@ -1,0 +1,123 @@
+import evaluateExpression from '../evaluateExpression'
+
+test('Testing basic buildObject', () => {
+  const testIn = {
+    operator: 'buildObject',
+    properties: [
+      {
+        key: 'key',
+        value: 'value',
+      },
+    ],
+  }
+  const testOut = {
+    key: 'value',
+  }
+  return evaluateExpression(testIn).then((result: any) => {
+    expect(result).toEqual(testOut)
+  })
+})
+
+test('Testing buildObject for handling erronouse input', () => {
+  const testIn = {
+    operator: 'buildObject',
+    properties: [
+      {
+        value: 'missing key',
+      },
+      {
+        key: 'key',
+        value: 'value',
+      },
+      {},
+      {
+        key: 'missing value',
+      },
+    ],
+  }
+  const testOut = {
+    key: 'value',
+  }
+  return evaluateExpression(testIn).then((result: any) => {
+    expect(result).toEqual(testOut)
+  })
+})
+
+test('Testing buildObject with evaluated key and value', () => {
+  const testIn = {
+    operator: 'buildObject',
+    properties: [
+      {
+        key: 'key',
+        value: 'value',
+      },
+      {
+        key: {
+          operator: 'objectProperties',
+          children: ['key'],
+        },
+        value: {
+          operator: 'objectProperties',
+          children: ['value'],
+        },
+      },
+    ],
+  }
+
+  const testOut = {
+    key: 'value',
+    keyFromObjects: 'valueFromObjects',
+  }
+
+  const params = {
+    objects: { key: 'keyFromObjects', value: 'valueFromObjects' },
+  }
+
+  return evaluateExpression(testIn, params).then((result: any) => {
+    expect(result).toEqual(testOut)
+  })
+})
+
+test('Testing buildObject with evaluations and nesting', () => {
+  const testIn = {
+    operator: 'buildObject',
+    properties: [
+      {
+        key: 'key',
+        value: 'value',
+      },
+      {
+        key: {
+          operator: 'objectProperties',
+          children: ['key'],
+        },
+        value: {
+          operator: 'buildObject',
+          properties: [
+            {
+              key: 'concatArray',
+              value: {
+                operator: '+',
+                children: [['one'], [2]],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+
+  const testOut = {
+    key: 'value',
+    keyFromObjects: { concatArray: ['one', 2] },
+  }
+
+  const params = {
+    objects: { key: 'keyFromObjects', value: 'valueFromObjects' },
+  }
+
+  return evaluateExpression(testIn, params).then((result: any) => {
+    console.log(result)
+    expect(result).toEqual(testOut)
+  })
+})

--- a/src/modules/expression-evaluator/src/resolvers/buildObject.test.ts
+++ b/src/modules/expression-evaluator/src/resolvers/buildObject.test.ts
@@ -5,20 +5,20 @@ test('Testing basic buildObject', () => {
     operator: 'buildObject',
     properties: [
       {
-        key: 'key',
-        value: 'value',
+        key: 'someKey',
+        value: 'someValue',
       },
     ],
   }
   const testOut = {
-    key: 'value',
+    someKey: 'someValue',
   }
   return evaluateExpression(testIn).then((result: any) => {
     expect(result).toEqual(testOut)
   })
 })
 
-test('Testing buildObject for handling erronouse input', () => {
+test('Testing buildObject for handling erroneous input', () => {
   const testIn = {
     operator: 'buildObject',
     properties: [
@@ -26,8 +26,8 @@ test('Testing buildObject for handling erronouse input', () => {
         value: 'missing key',
       },
       {
-        key: 'key',
-        value: 'value',
+        key: 'someKey',
+        value: 'someValue',
       },
       {},
       {
@@ -36,7 +36,7 @@ test('Testing buildObject for handling erronouse input', () => {
     ],
   }
   const testOut = {
-    key: 'value',
+    someKey: 'someValue',
   }
   return evaluateExpression(testIn).then((result: any) => {
     expect(result).toEqual(testOut)
@@ -48,8 +48,8 @@ test('Testing buildObject with evaluated key and value', () => {
     operator: 'buildObject',
     properties: [
       {
-        key: 'key',
-        value: 'value',
+        key: 'someKey',
+        value: 'someValue',
       },
       {
         key: {
@@ -65,7 +65,7 @@ test('Testing buildObject with evaluated key and value', () => {
   }
 
   const testOut = {
-    key: 'value',
+    someKey: 'someValue',
     keyFromObjects: 'valueFromObjects',
   }
 
@@ -83,8 +83,8 @@ test('Testing buildObject with evaluations and nesting', () => {
     operator: 'buildObject',
     properties: [
       {
-        key: 'key',
-        value: 'value',
+        key: 'someKey',
+        value: 'someValue',
       },
       {
         key: {
@@ -108,7 +108,7 @@ test('Testing buildObject with evaluations and nesting', () => {
   }
 
   const testOut = {
-    key: 'value',
+    someKey: 'someValue',
     keyFromObjects: { concatArray: ['one', 2] },
   }
 

--- a/src/modules/expression-evaluator/src/resolvers/buildObject.ts
+++ b/src/modules/expression-evaluator/src/resolvers/buildObject.ts
@@ -1,0 +1,35 @@
+import { EvaluateExpressionInstance, ValueNode, EvaluatorNode } from '../types'
+
+export type BuildObjectQuery = {
+  operator: 'buildObject'
+  properties: {
+    key: EvaluatorNode
+    value: EvaluatorNode
+  }[]
+}
+
+type BuildObject = (
+  buildObjectQuery: BuildObjectQuery,
+  evaluateExpressionInstance: EvaluateExpressionInstance
+) => Promise<ValueNode>
+
+const buildObject: BuildObject = async (buildObjectQuery, evaluateExpressionInstance) => {
+  const result: { [key: string]: ValueNode } = {}
+
+  const evaluateKeyValue = async (key: EvaluatorNode, value: EvaluatorNode) => {
+    const [resultKey, resultValue] = await Promise.all<ValueNode>([
+      evaluateExpressionInstance(key),
+      evaluateExpressionInstance(value),
+    ])
+    if (resultKey && typeof value !== 'undefined') result[String(resultKey)] = resultValue
+  }
+
+  const evaluations = (buildObjectQuery?.properties || []).map(({ key, value }) =>
+    evaluateKeyValue(key, value)
+  )
+  await Promise.all<ValueNode>(evaluations)
+
+  return result
+}
+
+export default buildObject

--- a/src/modules/expression-evaluator/src/types.ts
+++ b/src/modules/expression-evaluator/src/types.ts
@@ -28,7 +28,7 @@ export interface IParameters {
 export interface OperatorNode {
   operator: Operator
   type?: OutputType
-  children: Array<OperatorNode | ValueNode>
+  children?: Array<EvaluatorNode>
   value?: ValueNode // deprecated
 }
 
@@ -52,3 +52,14 @@ type Operator =
   | 'API'
   | 'pgSQL'
   | 'graphQL'
+
+export type EvaluatorNode = OperatorNode | ValueNode
+
+export type EvaluateExpression = (
+  inputQuery: EvaluatorNode,
+  params?: IParameters
+) => Promise<ValueNode>
+
+export type EvaluateExpressionInstance = (inputQuery: EvaluatorNode) => Promise<ValueNode>
+
+export type IsEvaluationExpression = (expressionOrValue: EvaluatorNode) => boolean

--- a/src/modules/expression-evaluator/tsconfig.json
+++ b/src/modules/expression-evaluator/tsconfig.json
@@ -68,5 +68,5 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   // "exclude": ["jest.config.js", "*.test.*"]
-  "files": ["src/evaluateExpression.ts", "src/types.ts"]
+  "files": ["src/evaluateExpression.ts"]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { BasicObject, OperatorNode, ValueNode } from '@openmsupply/expression-evaluator/lib/types'
+import { BasicObject, EvaluatorNode } from '@openmsupply/expression-evaluator/lib/types'
 import {
   ActionQueueStatus,
   ApplicationOutcome,
@@ -7,7 +7,6 @@ import {
   TriggerQueueStatus,
 } from './generated/graphql'
 
-export type EvaluatorNode = OperatorNode | ValueNode
 export interface ActionInTemplate {
   code: string
   path: string


### PR DESCRIPTION
Required for front end PR https://github.com/openmsupply/application-manager-web-app/pull/764: 

note: when this PR is merged we need to push evaluator

### Changes

* Default value field on element (note this is the full response value, plugin specific)
* Use new defaultValue in userEdit (now requires buildObject evaluation)
* Use EvaluatorNode type for evaluator

#### Evaluator Changes
* Fix deeply nested query bug, new test added (it won't pass in master)
* New buildObject evaluation (see below notes about evaluator)
* Would need to use new evaluator for this PR to compile, need to repeat the same evaluator related steps as per Testing in front end PR

### Testing
* See front end testing in PR 'X'
* Use back end branch #761F-testing (`https://github.com/openmsupply/application-manager-server/compare/%23761F-generic-default-value-handling-to-work-for-all-plugins...%23761F-testing`)
* Make sure to run the same steps for evaluator import from local file as per front end branch

### Notes about Evaluator

I've added a new resolve `buildObject`, see documentation change for the new format, which doesn't use the children syntax, which i think is very cumbersome and hard to use, I think it's too much work to change existing resolvers to conform with the new format but I think it might be worth doing at some stage.

I think it's easier to have resolver specific configuration shape then the generic children shape

```
{
    operator: "graphQL"
    query: "query getUser($id: Int!){user(id: $id) {listDemo}}"
    variables: [
        {
            key: "id"
            value: {
                "operator": "objectProperties", 
                "children": ["currentUser.id"]
            }
        }
    ]
    extractor: "user.listDemo"
}
```
VS
```
{
    operator: "graphQL",
    children: [
        "query getUser($id: Int!){user(id: $id) {listDemo}}",
        "",
        ["id"],
        {
            "operator": "objectProperties", 
            "children": ["currentUser.id"]
        },
        "user.listDemo"
    ]
}
```
