### PR TITLE
#719F permission policy getters can deal with empty string claims

### DIFF
--- a/database/buildSchema/02_jwt_config.sql
+++ b/database/buildSchema/02_jwt_config.sql
@@ -18,10 +18,15 @@ STABLE;
 CREATE FUNCTION jwt_get_boolean (jwt_key text)
   RETURNS boolean
   AS $$
-  SELECT
-    COALESCE(current_setting('jwt.claims.' || $1, TRUE)::bool, FALSE)
+BEGIN
+  IF jwt_get_text ($1) = 'true' THEN
+    RETURN TRUE;
+  ELSE
+    RETURN FALSE;
+  END IF;
+END;
 $$
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE;
 
 --
@@ -30,9 +35,14 @@ STABLE;
 CREATE FUNCTION jwt_get_bigint (jwt_key text)
   RETURNS bigint
   AS $$
-  SELECT
-    COALESCE(current_setting('jwt.claims.' || $1, TRUE)::bigint, 0)
+BEGIN
+  IF jwt_get_text ($1) = '' THEN
+    RETURN 0;
+  ELSE
+    RETURN jwt_get_text ($1)::bigint;
+  END IF;
+END;
 $$
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE;
 


### PR DESCRIPTION
When restricting by row level policies, I was getting error messages `"message": "invalid input syntax for type boolean: \"\"",` (or for boolean) after changing user, the problem would go away after some delay, but it made policy restricted demo unusable. 

I think if claim is already set, postgraphile would make it an empty string '' when jwt changed. And existing jwt helpers could handle absence of claims but not empty string when casting to bigint and boolean. I think the problem went away after a delay because session (pool?) was reset and no claims were set.

Replication:
`yarn pg_permissions` instead of just `yarn pg`

go to application list with some user, then change to another user that can also see this application list (but through different permission name), you should see an error (instead of empty list)