### PR TITLE
Server to use admin jwt for graphQL queries

### DIFF
--- a/docker/database.sh
+++ b/docker/database.sh
@@ -15,4 +15,4 @@ yarn postgraphile -c "postgres://postgres@localhost/tmf_app_manager" --watch --d
 sleep 3
 
 echo '--- ADDING DATA'
-./database/insert_data.sh
+./database/insert_data.sh laos

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -23,7 +23,7 @@ yarn postgraphile \
    -c "postgres://postgres@localhost/tmf_app_manager" \
    --watch \
    --disable-query-log \
-   -r graphile_user
+   -r graphile_user \
    -q '/postgraphile/graphql' \
    -i '/postgraphile/graphiql' | tee /var/log/application_manager/graphile.log &
 sleep 3

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -23,6 +23,7 @@ yarn postgraphile \
    -c "postgres://postgres@localhost/tmf_app_manager" \
    --watch \
    --disable-query-log \
+   -r graphile_user
    -q '/postgraphile/graphql' \
    -i '/postgraphile/graphiql' | tee /var/log/application_manager/graphile.log &
 sleep 3

--- a/src/components/graphQLConnect.ts
+++ b/src/components/graphQLConnect.ts
@@ -1,10 +1,12 @@
 import fetch from 'node-fetch'
 import * as config from '../config.json'
+import { getAdminJWT } from './permissions/loginHelpers'
 
 const endpoint = config.graphQLendpoint
 
 class GraphQLdb {
   private static _instance: GraphQLdb
+  adminJWT: string = ''
 
   // constructor() {}
 
@@ -13,11 +15,13 @@ class GraphQLdb {
   }
 
   public gqlQuery = async (query: string, variables = {}) => {
+    if (this.adminJWT === '') this.adminJWT = await getAdminJWT()
     const queryResult = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
+        Authorization: `Bearer ${this.adminJWT}`,
       },
       body: JSON.stringify({
         query: query,

--- a/src/components/permissions/loginHelpers.ts
+++ b/src/components/permissions/loginHelpers.ts
@@ -4,7 +4,7 @@ import { verify, sign } from 'jsonwebtoken'
 import { promisify } from 'util'
 import { nanoid } from 'nanoid'
 import { PermissionRow, TemplatePermissions } from './types'
-import { compileJWT } from './rowLevelPolicyHelpers'
+import { baseJWT, compileJWT } from './rowLevelPolicyHelpers'
 import { Organisation, UserOrg } from '../../types'
 
 const verifyPromise: any = promisify(verify)
@@ -69,7 +69,7 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
       userId: userId || newUserId,
       orgId,
       templatePermissionRows,
-      sessionId: returnSessionId
+      sessionId: returnSessionId,
     }),
     user: {
       userId: userId || newUserId,
@@ -79,7 +79,7 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
       email,
       dateOfBirth,
       organisation: selectedOrg?.[0],
-      sessionId: returnSessionId
+      sessionId: returnSessionId,
     },
     orgList,
   }
@@ -102,4 +102,8 @@ const getSignedJWT = async (JWTelements: object) => {
   return await signPromise(compileJWT(JWTelements), config.jwtSecret)
 }
 
-export { extractJWTfromHeader, getUserInfo, getTokenData }
+const getAdminJWT = async () => {
+  return await signPromise({ ...baseJWT, role: 'postgres' }, config.jwtSecret)
+}
+
+export { extractJWTfromHeader, getUserInfo, getTokenData, getAdminJWT }

--- a/src/components/permissions/rowLevelPolicyHelpers.ts
+++ b/src/components/permissions/rowLevelPolicyHelpers.ts
@@ -9,6 +9,8 @@ import {
 
 import { compileRowLevelPolicyRuleTypes } from './helpersConstants'
 
+export const baseJWT = { aud: 'postgraphile' }
+
 /* Compiles JWT from userInfo and PerissionRows
   in { userId: 1, ... }, [
   {
@@ -35,7 +37,7 @@ import { compileRowLevelPolicyRuleTypes } from './helpersConstants'
 const compileJWT = (JWTelements: any) => {
   const { userId, orgId, templatePermissionRows, sessionId } = JWTelements
 
-  let JWT = { userId, orgId, aud: 'postgraphile', sessionId }
+  let JWT = { ...baseJWT, userId, orgId, sessionId }
 
   templatePermissionRows.forEach((permissionRow: PermissionRow) => {
     const { restrictions, templateId, templatePermissionId } = permissionRow

--- a/utils/postgraphile_launch_permissions.sh
+++ b/utils/postgraphile_launch_permissions.sh
@@ -1,4 +1,3 @@
 #TO-DO: Replace string with variable for DB name
 
-# Note `graphile_user` instead of postgres
-npx postgraphile -c "postgres://graphile_user@localhost/tmf_app_manager" -C postgres --watch
+npx postgraphile -c "postgres://postgres@localhost/tmf_app_manager" -r graphile_user -C postgres --watch 


### PR DESCRIPTION
There was a problem running graphQL queries with server when permissions are enabled. 

### Changes

* Starting postgraphile with row level permission with postgres user but with default role 
* Add role as 'postgres' to admin JWT token (loaded into singleton graphQL provider)

### Problem Replication
* start PG with row policies enabled, try to start/create a review, graphQL query fails to get reviewData and review is locked (due to changeStatus action for locked returning 'can't resolve object')