### PR TITLE
#406 grant permissions to new templates on approval of company license

### DIFF
--- a/database/insertData/_common/02A_permission_names.js
+++ b/database/insertData/_common/02A_permission_names.js
@@ -53,6 +53,57 @@ exports.queries = [
       }
     }
   }`,
+  // applyImportPermit
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: {
+          name: "applyImportPermit"
+          permissionPolicyToPermissionPolicyId: {
+            connectByName: { name: "applyUserRestricted" }
+          }
+        }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  // applyDrugRegoMMC
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: {
+          name: "applyDrugRegoMMC"
+          permissionPolicyToPermissionPolicyId: {
+            connectByName: { name: "applyUserRestricted" }
+          }
+        }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
+  // applyDrugRegoMMD
+  `mutation createPermissionName {
+    createPermissionName(
+      input: {
+        permissionName: {
+          name: "applyDrugRegoMMD"
+          permissionPolicyToPermissionPolicyId: {
+            connectByName: { name: "applyUserRestricted" }
+          }
+        }
+      }
+    ) {
+      permissionName {
+        name
+      }
+    }
+  }`,
   // applyUserEdit
   `mutation createPermissionName {
     createPermissionName(

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -1449,9 +1449,9 @@ exports.queries = [
                       operator: "objectProperties"
                       children: ["applicationData.username"]
                     }
-                    orgName: {
+                    orgId: {
                       operator: "objectProperties"
-                      children: ["outputCumulative.organisation.name"]
+                      children: ["applicationData.orgId"]
                     }
                     permissionNames: ["reviewJoinOrg"]
                   }
@@ -1490,11 +1490,11 @@ exports.queries = [
                   parameterQueries: {
                     username: {
                       operator: "objectProperties"
-                      children: ["currentUser.username"]
+                      children: ["applicationData.username"]
                     }
-                    orgName: {
+                    orgId: {
                       operator: "objectProperties"
-                      children: ["currentUser.organisation.orgName"]
+                      children: ["applicationData.orgId"]
                     }
                     permissionNames: ["applyImportPermit"]
                   }
@@ -1543,11 +1543,11 @@ exports.queries = [
                   parameterQueries: {
                     username: {
                       operator: "objectProperties"
-                      children: ["currentUser.username"]
+                      children: ["applicationData.username"]
                     }
-                    orgName: {
+                    orgId: {
                       operator: "objectProperties"
-                      children: ["currentUser.organisation.orgName"]
+                      children: ["applicationData.orgId"]
                     }
                     permissionNames: ["applyDrugRegoMMC"]
                   }
@@ -1596,11 +1596,11 @@ exports.queries = [
                   parameterQueries: {
                     username: {
                       operator: "objectProperties"
-                      children: ["currentUser.username"]
+                      children: ["applicationData.username"]
                     }
-                    orgName: {
+                    orgId: {
                       operator: "objectProperties"
-                      children: ["currentUser.organisation.orgName"]
+                      children: ["applicationData.orgId"]
                     }
                     permissionNames: ["applyDrugRegoMMD"]
                   }

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -1431,34 +1431,6 @@ exports.queries = [
                 {
                   actionCode: "grantPermissions"
                   trigger: ON_REVIEW_SUBMIT
-                  sequence: 103
-                  # TO-DO -- update condition to just check Outcome
-                  # (from applicationData)
-                  condition: {
-                    operator: "="
-                    children: [
-                      {
-                        operator: "objectProperties"
-                        children: ["applicationData.outcome"]
-                      }
-                      "APPROVED"
-                    ]
-                  }
-                  parameterQueries: {
-                    username: {
-                      operator: "objectProperties"
-                      children: ["applicationData.username"]
-                    }
-                    orgId: {
-                      operator: "objectProperties"
-                      children: ["applicationData.orgId"]
-                    }
-                    permissionNames: ["reviewJoinOrg"]
-                  }
-                }
-                {
-                  actionCode: "grantPermissions"
-                  trigger: ON_REVIEW_SUBMIT
                   sequence: 104
                   # TO-DO -- update condition to just check Outcome
                   # (from applicationData)

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -1456,6 +1456,155 @@ exports.queries = [
                     permissionNames: ["reviewJoinOrg"]
                   }
                 }
+                {
+                  actionCode: "grantPermissions"
+                  trigger: ON_REVIEW_SUBMIT
+                  sequence: 104
+                  # TO-DO -- update condition to just check Outcome
+                  # (from applicationData)
+                  condition: {
+                    operator: "AND"
+                    children: [
+                      {
+                        operator: "="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.outcome"]
+                          }
+                          "APPROVED"
+                        ]
+                      }
+                      {
+                        operator: "="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.responses.Q2LicenseType.text"]
+                          }
+                          "import/export medicines and medical devices"
+                        ]
+                      }
+                    ]
+                  }
+                  parameterQueries: {
+                    username: {
+                      operator: "objectProperties"
+                      children: ["applicationData.username"]
+                    }
+                    orgName: {
+                      operator: "objectProperties"
+                      children: ["outputCumulative.organisation.name"]
+                    }
+                    permissionNames: ["applyImportPermit"]
+                  }
+                }
+                {
+                  actionCode: "grantPermissions"
+                  trigger: ON_REVIEW_SUBMIT
+                  sequence: 105
+                  # TO-DO -- update condition to just check Outcome
+                  # (from applicationData)
+                  condition: {
+                    operator: "AND"
+                    children: [
+                      {
+                        operator: "="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.outcome"]
+                          }
+                          "APPROVED"
+                        ]
+                      }
+                      {
+                        operator: "!="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.responses.Q2LicenseType.text"]
+                          }
+                          "import/export medicines and medical devices"
+                        ]
+                      }
+                      {
+                        operator: "="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.responses.Q1ProductType.text"]
+                          }
+                          "modern medicines"
+                        ]
+                      }
+                    ]
+                  }
+                  parameterQueries: {
+                    username: {
+                      operator: "objectProperties"
+                      children: ["applicationData.username"]
+                    }
+                    orgName: {
+                      operator: "objectProperties"
+                      children: ["outputCumulative.organisation.name"]
+                    }
+                    permissionNames: ["applyDrugRegoMMC"]
+                  }
+                }
+                {
+                  actionCode: "grantPermissions"
+                  trigger: ON_REVIEW_SUBMIT
+                  sequence: 105
+                  # TO-DO -- update condition to just check Outcome
+                  # (from applicationData)
+                  condition: {
+                    operator: "AND"
+                    children: [
+                      {
+                        operator: "="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.outcome"]
+                          }
+                          "APPROVED"
+                        ]
+                      }
+                      {
+                        operator: "!="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.responses.Q2LicenseType.text"]
+                          }
+                          "import/export medicines and medical devices"
+                        ]
+                      }
+                      {
+                        operator: "="
+                        children: [
+                          {
+                            operator: "objectProperties"
+                            children: ["applicationData.responses.Q1ProductType.text"]
+                          }
+                          "medical devices"
+                        ]
+                      }
+                    ]
+                  }
+                  parameterQueries: {
+                    username: {
+                      operator: "objectProperties"
+                      children: ["applicationData.username"]
+                    }
+                    orgName: {
+                      operator: "objectProperties"
+                      children: ["outputCumulative.organisation.name"]
+                    }
+                    permissionNames: ["applyDrugRegoMMD"]
+                  }
+                }
               ]
             }
             templatePermissionsUsingId: {

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -11,7 +11,7 @@ exports.queries = [
     createTemplate(
       input: {
           template: {
-            code: "CompanyLicense1"
+            code: "CompanyLicense"
             name: "Company License for Modern medicines or Medical devices"
             isLinear: false # CHANGE THIS
             status: AVAILABLE
@@ -1351,7 +1351,7 @@ exports.queries = [
                   actionCode: "cLog"
                   trigger: ON_APPLICATION_SUBMIT
                   parameterQueries: {
-                    message: { value: "Organisation Registration submission" }
+                    message: { value: "Company License submission" }
                   }
                 }
                 {

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -1490,11 +1490,11 @@ exports.queries = [
                   parameterQueries: {
                     username: {
                       operator: "objectProperties"
-                      children: ["applicationData.username"]
+                      children: ["currentUser.username"]
                     }
                     orgName: {
                       operator: "objectProperties"
-                      children: ["outputCumulative.organisation.name"]
+                      children: ["currentUser.organisation.orgName"]
                     }
                     permissionNames: ["applyImportPermit"]
                   }
@@ -1543,11 +1543,11 @@ exports.queries = [
                   parameterQueries: {
                     username: {
                       operator: "objectProperties"
-                      children: ["applicationData.username"]
+                      children: ["currentUser.username"]
                     }
                     orgName: {
                       operator: "objectProperties"
-                      children: ["outputCumulative.organisation.name"]
+                      children: ["currentUser.organisation.orgName"]
                     }
                     permissionNames: ["applyDrugRegoMMC"]
                   }
@@ -1596,11 +1596,11 @@ exports.queries = [
                   parameterQueries: {
                     username: {
                       operator: "objectProperties"
-                      children: ["applicationData.username"]
+                      children: ["currentUser.username"]
                     }
                     orgName: {
                       operator: "objectProperties"
-                      children: ["outputCumulative.organisation.name"]
+                      children: ["currentUser.organisation.orgName"]
                     }
                     permissionNames: ["applyDrugRegoMMD"]
                   }

--- a/database/insertData/laos/04_template_importPermit(blank).js
+++ b/database/insertData/laos/04_template_importPermit(blank).js
@@ -42,6 +42,15 @@ exports.queries = [
           templateCategoryToTemplateCategoryId: {
             connectByCode: { code: "license" }
           }
+          templateStagesUsingId: {
+            create: [
+              {
+                number: 1
+                title: "Automatic"
+                colour: "#1E14DB" #dark blue
+              }
+            ]
+          }
           ${joinFilters}
           templateActionsUsingId: {
             create: [
@@ -83,30 +92,14 @@ exports.queries = [
             ]
           }
           templatePermissionsUsingId: {
-                create: [
+            create: [
                 # Apply Company license (granted on Company registration)
                 {
                     permissionNameToPermissionNameId: {
                     connectByName: { name: "applyImportPermit" }
                     }
                 }
-                # Review General - Stage 1
-                {
-                    permissionNameToPermissionNameId: {
-                    connectByName: { name: "reviewGeneral" }
-                    }
-                    stageNumber: 1
-                    levelNumber: 1
-                }
-                # Assign General - Stage 1
-                {
-                    permissionNameToPermissionNameId: {
-                    connectByName: { name: "assignGeneral" }
-                    }
-                    stageNumber: 1
-                    levelNumber: 1
-                }
-                ]
+              ]
             }
         }
       }

--- a/database/insertData/laos/04_template_importPermit(blank).js
+++ b/database/insertData/laos/04_template_importPermit(blank).js
@@ -1,0 +1,121 @@
+/*
+TEMPLATE D - Import Permit
+  - Permissions is granted on approval of Company License (on specific options selected)
+*/
+
+const { coreActions, joinFilters } = require('../_helpers/core_mutations')
+
+exports.queries = [
+  `mutation {
+    createTemplate(
+      input: {
+        template: {
+          code: "importPermit"
+          name: "Import permit"
+          isLinear: true
+          status: AVAILABLE
+          startMessage: "## Apply for import permit of Modern medicines or Medical devices"
+          versionTimestamp: "NOW()"
+          templateSectionsUsingId: {
+            create: [
+              {
+                code: "S1"
+                title: "Applicant details"
+                index: 0
+                templateElementsUsingId: {
+                  create: [
+                    {
+                      code: "S1PB1"
+                      index: 10
+                      title: "Section 1 - Intro"
+                      elementTypePluginCode: "textInfo"
+                      category: INFORMATION
+                      parameters: {
+                        title: "### Place holder - fields to be created soon!"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+          templateCategoryToTemplateCategoryId: {
+            connectByCode: { code: "license" }
+          }
+          ${joinFilters}
+          templateActionsUsingId: {
+            create: [
+              ${coreActions}
+              {
+                actionCode: "cLog"
+                trigger: ON_APPLICATION_SUBMIT
+                parameterQueries: {
+                  message: { value: "Drug Registration (Modern Medicines) submission" }
+                }
+              }
+              {
+                actionCode: "changeOutcome"
+                trigger: ON_REVIEW_SUBMIT
+                sequence: 100
+                condition: {
+                  operator: "AND"
+                  children: [
+                    {
+                      operator: "="
+                      children: [
+                        {
+                          operator: "objectProperties"
+                          children: [
+                            "applicationData.reviewData.latestDecision.decision"
+                          ]
+                        }
+                        "CONFORM"
+                      ]
+                    }
+                    {
+                      operator: "objectProperties"
+                      children: ["applicationData.reviewData.isLastLevel"]
+                    }
+                  ]
+                }
+                parameterQueries: { newOutcome: { value: "APPROVED" } }
+              }
+            ]
+          }
+          templatePermissionsUsingId: {
+                create: [
+                # Apply Company license (granted on Company registration)
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "applyImportPermit" }
+                    }
+                }
+                # Review General - Stage 1
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "reviewGeneral" }
+                    }
+                    stageNumber: 1
+                    levelNumber: 1
+                }
+                # Assign General - Stage 1
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "assignGeneral" }
+                    }
+                    stageNumber: 1
+                    levelNumber: 1
+                }
+                ]
+            }
+        }
+      }
+    ) {
+      template {
+        code
+        name
+      }
+    }
+  }`,
+]
+

--- a/database/insertData/laos/04_template_importPermit(blank).js
+++ b/database/insertData/laos/04_template_importPermit(blank).js
@@ -59,7 +59,7 @@ exports.queries = [
                 actionCode: "cLog"
                 trigger: ON_APPLICATION_SUBMIT
                 parameterQueries: {
-                  message: { value: "Drug Registration (Modern Medicines) submission" }
+                  message: { value: "Import permit (Modern medicines or Medical devices) submission" }
                 }
               }
               {

--- a/database/insertData/laos/05_template_modernMedicineRego(blank).js
+++ b/database/insertData/laos/05_template_modernMedicineRego(blank).js
@@ -31,8 +31,17 @@ exports.queries = [
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
                       parameters: {
-                        title: "### Place holder - fields to be created soon!"
+                        title: "### Fields to be created soon!"
                       }
+                    }
+                    {
+                        code: "Q1"
+                        index: 20
+                        title: "Blank"
+                        elementTypePluginCode: "shortText"
+                        category: QUESTION
+                        isRequired: false
+                        parameters: { label: "Place holder" }
                     }
                   ]
                 }
@@ -41,6 +50,15 @@ exports.queries = [
           }
           templateCategoryToTemplateCategoryId: {
             connectByCode: { code: "drugRego" }
+          }
+          templateStagesUsingId: {
+            create: [
+              {
+                number: 1
+                title: "Automatic"
+                colour: "#1E14DB" #dark blue
+              }
+            ]
           }
           ${joinFilters}
           templateActionsUsingId: {
@@ -83,31 +101,15 @@ exports.queries = [
             ]
           }
           templatePermissionsUsingId: {
-                create: [
+            create: [
                 # Apply Company license (granted on Company registration)
                 {
                     permissionNameToPermissionNameId: {
                     connectByName: { name: "applyDrugRegoMMC" }
                     }
                 }
-                # Review General - Stage 1
-                {
-                    permissionNameToPermissionNameId: {
-                    connectByName: { name: "reviewGeneral" }
-                    }
-                    stageNumber: 1
-                    levelNumber: 1
-                }
-                # Assign General - Stage 1
-                {
-                    permissionNameToPermissionNameId: {
-                    connectByName: { name: "canAssignDrugRego" }
-                    }
-                    stageNumber: 1
-                    levelNumber: 1
-                }
-                ]
-            }
+            ]
+          }
         }
       }
     ) {

--- a/database/insertData/laos/05_template_modernMedicineRego(blank).js
+++ b/database/insertData/laos/05_template_modernMedicineRego(blank).js
@@ -1,0 +1,121 @@
+/*
+TEMPLATE E - Modern Medicine (Drug Registration)
+  - Permissions is granted on approval of Company License (on specific options selected)
+*/
+
+const { coreActions, joinFilters } = require('../_helpers/core_mutations')
+
+exports.queries = [
+  `mutation {
+    createTemplate(
+      input: {
+        template: {
+          code: "modernMedicineRego"
+          name: "Drug Registration MMC"
+          isLinear: true
+          status: AVAILABLE
+          startMessage: "## Apply for a drug registration of a medicine"
+          versionTimestamp: "NOW()"
+          templateSectionsUsingId: {
+            create: [
+              {
+                code: "S1"
+                title: "Modern medice details"
+                index: 0
+                templateElementsUsingId: {
+                  create: [
+                    {
+                      code: "S1PB1"
+                      index: 10
+                      title: "Section 1 - Intro"
+                      elementTypePluginCode: "textInfo"
+                      category: INFORMATION
+                      parameters: {
+                        title: "### Place holder - fields to be created soon!"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+          templateCategoryToTemplateCategoryId: {
+            connectByCode: { code: "drugRego" }
+          }
+          ${joinFilters}
+          templateActionsUsingId: {
+            create: [
+              ${coreActions}
+              {
+                actionCode: "cLog"
+                trigger: ON_APPLICATION_SUBMIT
+                parameterQueries: {
+                  message: { value: "Drug Registration (Modern Medicines) submission" }
+                }
+              }
+              {
+                actionCode: "changeOutcome"
+                trigger: ON_REVIEW_SUBMIT
+                sequence: 100
+                condition: {
+                  operator: "AND"
+                  children: [
+                    {
+                      operator: "="
+                      children: [
+                        {
+                          operator: "objectProperties"
+                          children: [
+                            "applicationData.reviewData.latestDecision.decision"
+                          ]
+                        }
+                        "CONFORM"
+                      ]
+                    }
+                    {
+                      operator: "objectProperties"
+                      children: ["applicationData.reviewData.isLastLevel"]
+                    }
+                  ]
+                }
+                parameterQueries: { newOutcome: { value: "APPROVED" } }
+              }
+            ]
+          }
+          templatePermissionsUsingId: {
+                create: [
+                # Apply Company license (granted on Company registration)
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "applyDrugRegoMMC" }
+                    }
+                }
+                # Review General - Stage 1
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "reviewGeneral" }
+                    }
+                    stageNumber: 1
+                    levelNumber: 1
+                }
+                # Assign General - Stage 1
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "canAssignDrugRego" }
+                    }
+                    stageNumber: 1
+                    levelNumber: 1
+                }
+                ]
+            }
+        }
+      }
+    ) {
+      template {
+        code
+        name
+      }
+    }
+  }`,
+]
+

--- a/database/insertData/laos/06_template_medicalDeviceRego(blank).js
+++ b/database/insertData/laos/06_template_medicalDeviceRego(blank).js
@@ -1,0 +1,121 @@
+/*
+TEMPLATE F - Medical Devices (Drug Registration)
+  - Permissions is granted on approval of Company License (on specific options selected)
+*/
+
+const { coreActions, joinFilters } = require('../_helpers/core_mutations')
+
+exports.queries = [
+  `mutation {
+    createTemplate(
+      input: {
+        template: {
+          code: "medicalDeviceRego"
+          name: "Drug Registration MMD"
+          isLinear: true
+          status: AVAILABLE
+          startMessage: "## Apply for a drug registration for a medical devices"
+          versionTimestamp: "NOW()"
+          templateSectionsUsingId: {
+            create: [
+              {
+                code: "S1"
+                title: "Medical device details"
+                index: 0
+                templateElementsUsingId: {
+                  create: [
+                    {
+                      code: "S1PB1"
+                      index: 10
+                      title: "Section 1 - Intro"
+                      elementTypePluginCode: "textInfo"
+                      category: INFORMATION
+                      parameters: {
+                        title: "### Place holder - fields to be created soon!"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+          templateCategoryToTemplateCategoryId: {
+            connectByCode: { code: "drugRego" }
+          }
+          ${joinFilters}
+          templateActionsUsingId: {
+            create: [
+              ${coreActions}
+              {
+                actionCode: "cLog"
+                trigger: ON_APPLICATION_SUBMIT
+                parameterQueries: {
+                  message: { value: "Drug Registration (Medical device) submission" }
+                }
+              }
+              {
+                actionCode: "changeOutcome"
+                trigger: ON_REVIEW_SUBMIT
+                sequence: 100
+                condition: {
+                  operator: "AND"
+                  children: [
+                    {
+                      operator: "="
+                      children: [
+                        {
+                          operator: "objectProperties"
+                          children: [
+                            "applicationData.reviewData.latestDecision.decision"
+                          ]
+                        }
+                        "CONFORM"
+                      ]
+                    }
+                    {
+                      operator: "objectProperties"
+                      children: ["applicationData.reviewData.isLastLevel"]
+                    }
+                  ]
+                }
+                parameterQueries: { newOutcome: { value: "APPROVED" } }
+              }
+             ]
+           }
+           templatePermissionsUsingId: {
+                create: [
+                # Apply Company license (granted on Company registration)
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "applyOrgLicense" }
+                    }
+                }
+                # Review General - Stage 1
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "reviewGeneral" }
+                    }
+                    stageNumber: 1
+                    levelNumber: 1
+                }
+                # Assign General - Stage 1
+                {
+                    permissionNameToPermissionNameId: {
+                    connectByName: { name: "assignGeneral" }
+                    }
+                    stageNumber: 1
+                    levelNumber: 1
+                }
+                ]
+            }
+        }
+      }
+    ) {
+      template {
+        code
+        name
+      }
+    }
+  }`,
+]
+

--- a/database/insertData/laos/06_template_medicalDeviceRego(blank).js
+++ b/database/insertData/laos/06_template_medicalDeviceRego(blank).js
@@ -31,8 +31,17 @@ exports.queries = [
                       elementTypePluginCode: "textInfo"
                       category: INFORMATION
                       parameters: {
-                        title: "### Place holder - fields to be created soon!"
+                        title: "### Fields to be created soon!"
                       }
+                    }
+                    {
+                        code: "Q1"
+                        index: 20
+                        title: "Blank"
+                        elementTypePluginCode: "shortText"
+                        category: QUESTION
+                        isRequired: false
+                        parameters: { label: "Place holder" }
                     }
                   ]
                 }
@@ -41,6 +50,15 @@ exports.queries = [
           }
           templateCategoryToTemplateCategoryId: {
             connectByCode: { code: "drugRego" }
+          }
+          templateStagesUsingId: {
+            create: [
+              {
+                number: 1
+                title: "Automatic"
+                colour: "#1E14DB" #dark blue
+              }
+            ]
           }
           ${joinFilters}
           templateActionsUsingId: {
@@ -83,30 +101,14 @@ exports.queries = [
              ]
            }
            templatePermissionsUsingId: {
-                create: [
+              create: [
                 # Apply Company license (granted on Company registration)
                 {
                     permissionNameToPermissionNameId: {
-                    connectByName: { name: "applyOrgLicense" }
+                    connectByName: { name: "applyDrugRegoMMD" }
                     }
                 }
-                # Review General - Stage 1
-                {
-                    permissionNameToPermissionNameId: {
-                    connectByName: { name: "reviewGeneral" }
-                    }
-                    stageNumber: 1
-                    levelNumber: 1
-                }
-                # Assign General - Stage 1
-                {
-                    permissionNameToPermissionNameId: {
-                    connectByName: { name: "assignGeneral" }
-                    }
-                    stageNumber: 1
-                    levelNumber: 1
-                }
-                ]
+              ]
             }
         }
       }

--- a/documentation/List-of-Action-plugins.md
+++ b/documentation/List-of-Action-plugins.md
@@ -163,8 +163,9 @@ Grants permission to user/org -- i.e. creates `permission_join` from user/org to
 | Input parameters<br />(\*required) <br/> | Output properties   |
 | ---------------------------------------- | ------------------- |
 | `username`\*                             | `permissionJoinIds` |
-| `orgName`                                | `permissionNames`   |
-| `permissionNames`\* [Array of names]     |                     |
+| `permissionNames`\* [Array of names]     | `permissionNames`   |
+| `orgName`                                |                     |
+| `orgId`                                  |                     |
 
 ---
 

--- a/plugins/action_grant_permissions/plugin.json
+++ b/plugins/action_grant_permissions/plugin.json
@@ -4,7 +4,7 @@
   "name": "Grant Permissions",
   "description": "Grants permission to user/org, creates permission join from user/org to permission name. If org not provided, the permission will be granted to the user only.",
   "required_parameters": ["username", "permissionNames"],
-  "optional_parameters": ["orgName"],
+  "optional_parameters": ["orgName", "orgId"],
   "output_properties": ["permissionJoinIds", "permissionNames"],
   "info": {
     "author": {

--- a/plugins/action_grant_permissions/src/grantPermissions.test.ts
+++ b/plugins/action_grant_permissions/src/grantPermissions.test.ts
@@ -16,12 +16,18 @@ const testParams2 = {
   permissionNames: ['reviewOrgRego'],
 }
 
+const testParams3 = {
+  username: 'nmadruga',
+  orgId: 1, // "Drugs-R-Us"
+  permissionNames: ['reviewOrgRego'],
+}
+
 test('Test: Add permission to Valerio', () => {
   return grantPermissions({ parameters: testParams, DBConnect }).then((result: any) => {
     expect(result).toEqual({
       status: ActionQueueStatus.Success,
       output: {
-        permissionJoinIds: [41],
+        permissionJoinIds: [40],
         permissionNames: ['reviewOrgRego'],
       },
       error_log: '',
@@ -35,7 +41,7 @@ test('Test: Add permission to Valerio, already exists', () => {
     expect(result).toEqual({
       status: ActionQueueStatus.Success,
       output: {
-        permissionJoinIds: [41],
+        permissionJoinIds: [40],
         permissionNames: ['reviewOrgRego'],
       },
       error_log: '',
@@ -49,7 +55,7 @@ test('Test: Add permission to Carl and Medicinal Importers, Ltd.', () => {
     expect(result).toEqual({
       status: ActionQueueStatus.Success,
       output: {
-        permissionJoinIds: [43],
+        permissionJoinIds: [42],
         permissionNames: ['reviewOrgRego'],
       },
       error_log: '',
@@ -63,7 +69,20 @@ test('Test: Add permission to Carl and Medicinal Importers, Ltd., already exists
     expect(result).toEqual({
       status: ActionQueueStatus.Success,
       output: {
-        permissionJoinIds: [43],
+        permissionJoinIds: [42],
+        permissionNames: ['reviewOrgRego'],
+      },
+      error_log: '',
+    })
+  })
+})
+
+test('Test: Add permission to Nicole and "Drugs-R-Us" using orgId', () => {
+  return grantPermissions({ parameters: testParams3, DBConnect }).then((result: any) => {
+    expect(result).toEqual({
+      status: ActionQueueStatus.Success,
+      output: {
+        permissionJoinIds: [44],
         permissionNames: ['reviewOrgRego'],
       },
       error_log: '',

--- a/plugins/action_grant_permissions/src/grantPermissions.ts
+++ b/plugins/action_grant_permissions/src/grantPermissions.ts
@@ -2,18 +2,19 @@ import { ActionQueueStatus } from '../../../src/generated/graphql'
 import { ActionPluginInput } from '../../types'
 
 const grantPermissions = async ({ parameters, DBConnect }: ActionPluginInput) => {
-  const { username, orgName, permissionNames } = parameters
+  const { username, orgName, orgId, permissionNames } = parameters
   try {
-    console.log('\nGranting permission/s:')
-    console.log({ username, orgName, permissionNames })
+    console.log('\nGranting permissions:')
+    console.log({ username, orgName, orgId, permissionNames })
 
     const permissionJoinIds = []
     const outputNames = []
 
     for (const permissionName of permissionNames) {
-      const permissionJoinId = orgName
-        ? await DBConnect.joinPermissionNameToUserOrg(username, orgName, permissionName)
-        : await DBConnect.joinPermissionNameToUser(username, permissionName)
+      const permissionJoinId =
+        orgName || orgId // Can use either one to create a permission_join with a company
+          ? await DBConnect.joinPermissionNameToUserOrg(username, orgName || orgId, permissionName)
+          : await DBConnect.joinPermissionNameToUser(username, permissionName)
       permissionJoinIds.push(permissionJoinId)
       if (permissionJoinId) outputNames.push(permissionName)
     }

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -651,26 +651,17 @@ class PostgresDB {
     org: string | number,
     permissionName: string
   ) => {
-    const text =
-      typeof org === 'number'
-        ? `
-      INSERT INTO permission_join (user_id, organisation_id, permission_name_id)
-      VALUES (
-        (select id from "user" where username = $1),
-        $2,
-        (select id from permission_name where name = $3)
-      ) RETURNING id`
-        : `
-    insert into permission_join (user_id, organisation_id, permission_name_id) 
+    const text = `
+    INSERT INTO permission_join (user_id, organisation_id, permission_name_id) 
     values (
         (select id from "user" where username = $1),
-        (select id from organisation where name = $2),
+        ${typeof org === 'number' ? '$2' : '(select id from organisation where name = $2)'},
         (select id from permission_name where name = $3))
     ON CONFLICT (user_id, organisation_id, permission_name_id)
       WHERE organisation_id IS NOT NULL
     DO
     		UPDATE SET user_id = (select id from "user" where username = $1)
-    returning id
+    RETURNING id
     `
     try {
       const result = await this.query({ text, values: [username, org, permissionName] })


### PR DESCRIPTION
Fixes #406

### Changes
- Add `grantPermission` to apply to either `importPermit`, `drugRegoMMD` and `drugRegoMMC` depending on what was selected in the `companyLicense` application.
- Update action `grantPermission` to also take `orgId` (instead of `orgName`) when create a new permission_join between user, organisation and template.