### PR TITLE
#409 Link company license to company registration application

### DIFF
--- a/database/insertData/laos/02_template_orgRegistration.js
+++ b/database/insertData/laos/02_template_orgRegistration.js
@@ -1073,6 +1073,24 @@ exports.queries = [
                   permissionNames: ["reviewJoinOrg", "applyOrgLicense"]
                 }
               }
+              {
+                actionCode: "changeStatus"
+                trigger: ON_REVIEW_SUBMIT
+                sequence: 104
+                condition: {
+                  operator: "="
+                  children: [
+                    {
+                      operator: "objectProperties"
+                      children: [
+                        "applicationData.outcome"
+                      ]
+                    }
+                    "APPROVED"
+                  ]
+                }
+                parameterQueries: { newStatus: { value: "COMPLETED" } }
+              }
             ]
           }
           templatePermissionsUsingId: {

--- a/database/insertData/laos/02_template_orgRegistration.js
+++ b/database/insertData/laos/02_template_orgRegistration.js
@@ -938,7 +938,7 @@ exports.queries = [
                   }
                   registration: {
                     operator: "objectProperties"
-                    children: ["applicationData.responses.registrationCode.text"]
+                    children: ["applicationData.responses.registrationCode.text", ""]
                   }
                   logo_url: {
                     operator: "+",

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -838,6 +838,34 @@ exports.queries = [
                         }
                       }
                       {
+                        code: "S3applicationLink"
+                        index: 65
+                        title: "Link to Company Registration application"
+                        elementTypePluginCode: "textInfo"
+                        category: INFORMATION
+                        parameters: { 
+                          text: {
+                            operator: "stringSubstitution",
+                            children: [
+                              "Original company application, with supplied documents: [click here](/application/%2)",
+                              {
+                                operator: "graphQL",
+                                children: [
+                                  "query getApplication($id: Int!) {organisationApplicationJoin(id: $id) {id,    application {id, name, serial}}}",
+                                  "graphQLEndpoint",
+                                  [
+                                    "id"
+                                  ],
+                                  1,
+                                  "organisationApplicationJoin.application.serial"
+                                ]
+                              }
+                            ]
+                          }
+                          style: "basic"
+                        }
+                      }
+                      {
                         code: "S3PB1"
                         index: 70
                         title: "Page Break"

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -847,7 +847,7 @@ exports.queries = [
                           text: {
                             operator: "stringSubstitution",
                             children: [
-                              "Link: **[Company application](/application/%2/summary?active-sections=S3)**, (with original documents)",
+                              "**Link: [Company application](/application/%2/summary?active-sections=S3)** (with original documents)",
                               {
                                 operator: "graphQL",
                                 children: [

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -847,7 +847,7 @@ exports.queries = [
                           text: {
                             operator: "stringSubstitution",
                             children: [
-                              "Original company application, with supplied documents: [click here](/application/%2/summary?active-sections=S3)",
+                              "Link: **[Company application](/application/%2/summary?active-sections=S3)**, (with original documents)",
                               {
                                 operator: "graphQL",
                                 children: [

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -838,7 +838,7 @@ exports.queries = [
                         }
                       }
                       {
-                        code: "S3applicationLink"
+                        code: "S3OutcomeLink"
                         index: 65
                         title: "Link to Company Registration application"
                         elementTypePluginCode: "textInfo"
@@ -847,22 +847,14 @@ exports.queries = [
                           text: {
                             operator: "stringSubstitution",
                             children: [
-                              "**Link: [Company application](/application/%2/summary?active-sections=S3)** (with original documents)",
+                              "**Link: [Company details](/outcomes/organisation/%1)**  \\n(including original application)",
                               {
-                                operator: "graphQL",
-                                children: [
-                                  "query getApplication($id: Int!) {organisationApplicationJoin(id: $id) {id,    application {id, name, serial}}}",
-                                  "graphQLEndpoint",
-                                  [
-                                    "id"
-                                  ],
-                                  1,
-                                  "organisationApplicationJoin.application.serial"
-                                ]
+                                operator: "objectProperties",
+                                children: [ "applicationData.org.id", "" ]
                               }
                             ]
                           }
-                          style: "basic"
+                          style: "none"
                         }
                       }
                       {

--- a/database/insertData/laos/03_template_license_MMC_MMD.js
+++ b/database/insertData/laos/03_template_license_MMC_MMD.js
@@ -847,7 +847,7 @@ exports.queries = [
                           text: {
                             operator: "stringSubstitution",
                             children: [
-                              "Original company application, with supplied documents: [click here](/application/%2)",
+                              "Original company application, with supplied documents: [click here](/application/%2/summary?active-sections=S3)",
                               {
                                 operator: "graphQL",
                                 children: [


### PR DESCRIPTION
Fixes #409 

Adds a "TextInfo" element to "Company Details" section of Company License application that provides a link to the original Company Registration application.

Made a few small changes to front-end to best reflect this -- see [front-end #795](https://github.com/openmsupply/application-manager-web-app/pull/795)

### Additional changes

- Added "Change Status" to "Completed" action to Company Registration template -- was missing.