### PR TITLE
#413-adjust-review-visibility-policy

### DIFF
--- a/database/insertData/_common/01_permission_policies.js
+++ b/database/insertData/_common/01_permission_policies.js
@@ -145,7 +145,17 @@ exports.queries = [
         },
         review: {
           view: {
-            reviewer_id: 'jwtUserDetails_bigint_userId',
+            application_id: {
+              $in: {
+                $select: {
+                  application_id: true,
+                  $from: 'review_assignment',
+                  $where: {
+                    reviewer_id: 'jwtUserDetails_bigint_userId',
+                  },
+                },
+              },
+            },
           },
         },
         review_assignment: {


### PR DESCRIPTION
@nmadruga does this work now as per the use case you've mentioned ? (I've tested, seems to work with my example, although in my example consolidator's response were visible, but not their name, after this change their name appeared, which suggests review became visible)

### Changes

* restrict review by review assignment application_id (vs reviewer_id)