### PR TITLE
#430 Auto-update timestamp when application_response is updated

### DIFF
--- a/database/buildSchema/22_application_response.sql
+++ b/database/buildSchema/22_application_response.sql
@@ -16,3 +16,26 @@ CREATE TABLE public.application_response (
     time_submitted timestamptz
 );
 
+-- Function to automatically update "time_updated"
+CREATE OR REPLACE FUNCTION public.update_response_timestamp ()
+    RETURNS TRIGGER
+    AS $application_event$
+BEGIN
+    UPDATE
+        public.application_response
+    SET
+        time_updated = NOW()
+    WHERE
+        id = NEW.id;
+    RETURN NULL;
+END;
+$application_event$
+LANGUAGE plpgsql;
+
+--TRIGGER to run above function when response is updated
+CREATE TRIGGER outcome_trigger
+    AFTER UPDATE OF status,
+    value,
+    is_valid ON public.application_response
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_response_timestamp ()


### PR DESCRIPTION
Fixes #430 

Simple Postgres Function and Trigger to automatically update the "time_updated" timestamp whenever the `status`, `value` or `is_valid` is modified, so we don't need to manually patch this value from front-end

### Testing

Change a value in a response (either manually, or via GraphQL or front-end) -- observe the time_updated field now shows the current time.