### PR TITLE
#445 add canMakeFinalDecision to user and template

### DIFF
--- a/database/buildSchema/13_template_permission.sql
+++ b/database/buildSchema/13_template_permission.sql
@@ -5,6 +5,7 @@ CREATE TABLE public.template_permission (
     template_id integer REFERENCES public.template (id),
     allowed_sections varchar[] DEFAULT NULL,
     can_self_assign boolean NOT NULL DEFAULT false,
+    can_make_final_decision boolean NOT NULL DEFAULT false,
     stage_number integer,
     level_number integer,
     restrictions jsonb

--- a/database/buildSchema/13_template_permission.sql
+++ b/database/buildSchema/13_template_permission.sql
@@ -21,6 +21,7 @@ CREATE VIEW permissions_all AS (
         template_permission.level_number AS "reviewLevel", 
         template_permission.allowed_sections AS "allowedSections",
         template_permission.can_self_assign AS "canSelfAssign",
+        template_permission.can_make_final_decision AS "canMakeFinalDecision",
         template_permission.restrictions AS "restrictions",
         permission_policy.name AS "policyName",
         permission_policy.type AS "permissionType",

--- a/database/insertData/_helpers/core_mutations.js
+++ b/database/insertData/_helpers/core_mutations.js
@@ -149,15 +149,32 @@ exports.coreActions = `
         operator: "AND"
         children: [
           {
-            operator: "="
+            operator: "OR",
             children: [
               {
-                operator: "objectProperties"
+                operator: "=",
                 children: [
-                  "applicationData.reviewData.latestDecision.decision"
+                  {
+                    operator: "objectProperties",
+                    children: [
+                      "applicationData.reviewData.latestDecision.decision"
+                    ]
+                  },
+                  "CONFORM"
+                ]
+              },
+              {
+                operator: "=",
+                children: [
+                  {
+                    operator: "objectProperties",
+                    children: [
+                      "applicationData.reviewData.latestDecision.decision"
+                    ]
+                  },
+                  "NON_CONFORM"
                 ]
               }
-              "CONFORM"
             ]
           }
           {

--- a/database/insertData/dev/03_template_D_basicReviewTesting.js
+++ b/database/insertData/dev/03_template_D_basicReviewTesting.js
@@ -312,6 +312,7 @@ exports.queries = [
                 }
                 stageNumber: 3
                 levelNumber: 1
+                canMakeFinalDecision: true
               }
               # Assign general
               {

--- a/database/insertData/dev/04_users.js
+++ b/database/insertData/dev/04_users.js
@@ -266,11 +266,6 @@ exports.queries = [
                   connectByName: { name: "reviewReviewTestAssessmentLvl2" }
                 }
               }
-              {
-                permissionNameToPermissionNameId: {
-                  connectByName: { name: "reviewReviewTestApproval" }
-                }
-              }
             ]
           }
         }
@@ -476,6 +471,57 @@ exports.queries = [
               {
                 permissionNameToPermissionNameId: {
                   connectByName: { name: "canAssessDrugRego" }
+                }
+              }
+            ]
+          }
+        }
+      }
+    ) {
+      user {
+        username
+      }
+    }
+  }`,
+  // Final decision users
+  `mutation {
+    createUser(
+      input: {
+        user: {
+          username: "finalDecision1"
+          firstName: "Final"
+          lastName: "Decision Maker 1"
+          passwordHash: "$2a$10$5R5ruFOLgrjOox5oH0I67.Rez7qGCEwf2a60Pe2TpfmIN99Dr0uW."
+          permissionJoinsUsingId: {
+            create: [
+              {
+                permissionNameToPermissionNameId: {
+                  connectByName: { name: "reviewReviewTestApproval" }
+                }
+              }
+            ]
+          }
+        }
+      }
+    ) {
+      user {
+        username
+      }
+    }
+  }`,
+  `mutation {
+    createUser(
+      input: {
+        user: {
+          username: "finalDecision2"
+          firstName: "Final"
+          lastName: "Decision Maker 2"
+          passwordHash: "$2a$10$5R5ruFOLgrjOox5oH0I67.Rez7qGCEwf2a60Pe2TpfmIN99Dr0uW."
+          permissionJoinsUsingId: {
+            create: [
+              {
+                permissionNameToPermissionNameId: {
+                  connectByName: { name: "reviewReviewTestApproval" }
                 }
               }
             ]

--- a/database/insertData/dev/04_users.js
+++ b/database/insertData/dev/04_users.js
@@ -491,7 +491,7 @@ exports.queries = [
           username: "finalDecision1"
           firstName: "Final"
           lastName: "Decision Maker 1"
-          passwordHash: "$2a$10$5R5ruFOLgrjOox5oH0I67.Rez7qGCEwf2a60Pe2TpfmIN99Dr0uW."
+          passwordHash: "$2a$10$5SZSiEj2RqgZzKu4.aCeFOicNo8f9cgXfCqK0k5ioNgGwTJvC42jG"
           permissionJoinsUsingId: {
             create: [
               {
@@ -516,7 +516,7 @@ exports.queries = [
           username: "finalDecision2"
           firstName: "Final"
           lastName: "Decision Maker 2"
-          passwordHash: "$2a$10$5R5ruFOLgrjOox5oH0I67.Rez7qGCEwf2a60Pe2TpfmIN99Dr0uW."
+          passwordHash: "$2a$10$DHIKam/EQItFhIBA5I4wduldlnc4n/0w42RJ9.SBA5htb4cZ/iEvi"
           permissionJoinsUsingId: {
             create: [
               {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -12831,6 +12831,7 @@ export type PermissionsAll = {
   reviewLevel?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   restrictions?: Maybe<Scalars['JSON']>;
   policyName?: Maybe<Scalars['String']>;
   permissionType?: Maybe<PermissionPolicyType>;
@@ -12864,6 +12865,8 @@ export type PermissionsAllCondition = {
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Checks for equality with the object’s `canSelfAssign` field. */
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `canMakeFinalDecision` field. */
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `restrictions` field. */
   restrictions?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `policyName` field. */
@@ -12904,6 +12907,8 @@ export type PermissionsAllFilter = {
   allowedSections?: Maybe<StringListFilter>;
   /** Filter by the object’s `canSelfAssign` field. */
   canSelfAssign?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `canMakeFinalDecision` field. */
+  canMakeFinalDecision?: Maybe<BooleanFilter>;
   /** Filter by the object’s `restrictions` field. */
   restrictions?: Maybe<JsonFilter>;
   /** Filter by the object’s `policyName` field. */
@@ -12973,6 +12978,8 @@ export enum PermissionsAllsOrderBy {
   AllowedSectionsDesc = 'ALLOWED_SECTIONS_DESC',
   CanSelfAssignAsc = 'CAN_SELF_ASSIGN_ASC',
   CanSelfAssignDesc = 'CAN_SELF_ASSIGN_DESC',
+  CanMakeFinalDecisionAsc = 'CAN_MAKE_FINAL_DECISION_ASC',
+  CanMakeFinalDecisionDesc = 'CAN_MAKE_FINAL_DECISION_DESC',
   RestrictionsAsc = 'RESTRICTIONS_ASC',
   RestrictionsDesc = 'RESTRICTIONS_DESC',
   PolicyNameAsc = 'POLICY_NAME_ASC',
@@ -33171,6 +33178,7 @@ export type PermissionsAllResolvers<ContextType = any, ParentType extends Resolv
   reviewLevel?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   allowedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   canSelfAssign?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  canMakeFinalDecision?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   restrictions?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   policyName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   permissionType?: Resolver<Maybe<ResolversTypes['PermissionPolicyType']>, ParentType, ContextType>;

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -20664,6 +20664,7 @@ export type TemplatePermission = Node & {
   templateId?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign: Scalars['Boolean'];
+  canMakeFinalDecision: Scalars['Boolean'];
   stageNumber?: Maybe<Scalars['Int']>;
   levelNumber?: Maybe<Scalars['Int']>;
   restrictions?: Maybe<Scalars['JSON']>;
@@ -20688,6 +20689,8 @@ export type TemplatePermissionCondition = {
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Checks for equality with the object’s `canSelfAssign` field. */
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `canMakeFinalDecision` field. */
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `stageNumber` field. */
   stageNumber?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `levelNumber` field. */
@@ -20708,6 +20711,8 @@ export type TemplatePermissionFilter = {
   allowedSections?: Maybe<StringListFilter>;
   /** Filter by the object’s `canSelfAssign` field. */
   canSelfAssign?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `canMakeFinalDecision` field. */
+  canMakeFinalDecision?: Maybe<BooleanFilter>;
   /** Filter by the object’s `stageNumber` field. */
   stageNumber?: Maybe<IntFilter>;
   /** Filter by the object’s `levelNumber` field. */
@@ -20737,6 +20742,7 @@ export type TemplatePermissionInput = {
   templateId?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   levelNumber?: Maybe<Scalars['Int']>;
   restrictions?: Maybe<Scalars['JSON']>;
@@ -20793,6 +20799,7 @@ export type TemplatePermissionPatch = {
   templateId?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   levelNumber?: Maybe<Scalars['Int']>;
   restrictions?: Maybe<Scalars['JSON']>;
@@ -20860,6 +20867,7 @@ export type TemplatePermissionPermissionNameIdFkeyTemplatePermissionCreateInput 
   templateId?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   levelNumber?: Maybe<Scalars['Int']>;
   restrictions?: Maybe<Scalars['JSON']>;
@@ -20902,6 +20910,8 @@ export enum TemplatePermissionsOrderBy {
   AllowedSectionsDesc = 'ALLOWED_SECTIONS_DESC',
   CanSelfAssignAsc = 'CAN_SELF_ASSIGN_ASC',
   CanSelfAssignDesc = 'CAN_SELF_ASSIGN_DESC',
+  CanMakeFinalDecisionAsc = 'CAN_MAKE_FINAL_DECISION_ASC',
+  CanMakeFinalDecisionDesc = 'CAN_MAKE_FINAL_DECISION_DESC',
   StageNumberAsc = 'STAGE_NUMBER_ASC',
   StageNumberDesc = 'STAGE_NUMBER_DESC',
   LevelNumberAsc = 'LEVEL_NUMBER_ASC',
@@ -20979,6 +20989,7 @@ export type TemplatePermissionTemplateIdFkeyTemplatePermissionCreateInput = {
   permissionNameId?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   levelNumber?: Maybe<Scalars['Int']>;
   restrictions?: Maybe<Scalars['JSON']>;
@@ -25907,6 +25918,7 @@ export type UpdateTemplatePermissionOnTemplatePermissionForTemplatePermissionPer
   templateId?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   levelNumber?: Maybe<Scalars['Int']>;
   restrictions?: Maybe<Scalars['JSON']>;
@@ -25920,6 +25932,7 @@ export type UpdateTemplatePermissionOnTemplatePermissionForTemplatePermissionTem
   permissionNameId?: Maybe<Scalars['Int']>;
   allowedSections?: Maybe<Array<Maybe<Scalars['String']>>>;
   canSelfAssign?: Maybe<Scalars['Boolean']>;
+  canMakeFinalDecision?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   levelNumber?: Maybe<Scalars['Int']>;
   restrictions?: Maybe<Scalars['JSON']>;
@@ -33770,6 +33783,7 @@ export type TemplatePermissionResolvers<ContextType = any, ParentType extends Re
   templateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   allowedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   canSelfAssign?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  canMakeFinalDecision?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   stageNumber?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   levelNumber?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   restrictions?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;


### PR DESCRIPTION
Fixes #445 

### Briefing
Initial changes as discussed for [EPIC#34](https://github.com/openmsupply/application-manager-web-app/issues/334). So this PR doesn't actually has the full functionality yet, is just adding a new field and allowing the stage to go to next stages when either decision is CONFORM or NON_CONFORM and `is_last_level` reviewer.

❓ Can we guarantee that when the review is submitted on the last level of one given stage the `is_last_level` is set to true? Since this isn't an automatic generated column in `review_assignment` I wasn't sure.

### Changes
- Added field to template_permission as discussed in Planning
- 2 new users **finalDecision1** and **finalDecision2** already created with new permission_name to make final approval (existing so I didn't change the name, let me know if best to): `reviewReviewTestApproval`.
- Add new field `canMakeFinalDecision` on creation of `template_permission` in Review Test template. 
- Updated conditions sent to action `incrementStage` in **core_actions** to also accept decision of NON_CONFORM to move to the next stage.

### Tests
- I was only testing to CONFORM/NON_CONFORM one application of Review Test template to go from stage Assessment to Final Decision. To do this just log in with either Consolidator1 or Consolidator2 and submit one application on the correct stage with one of the decisions.