### PR TITLE
426(part 2) "serial_pattern" field for template

### DIFF
--- a/database/buildSchema/07B_template.sql
+++ b/database/buildSchema/07B_template.sql
@@ -9,6 +9,10 @@ CREATE TABLE public.template (
     id serial PRIMARY KEY,
     name varchar,
     code varchar NOT NULL,
+    serial_pattern jsonb DEFAULT '{
+        "pattern": "GEN-[A-Z]{3}-<+dddd>",
+        "counterName": "general"
+    }' ::jsonb,
     is_linear boolean DEFAULT TRUE,
     start_message jsonb,
     status public.template_status,

--- a/database/buildSchema/20_application_stage_status.sql
+++ b/database/buildSchema/20_application_stage_status.sql
@@ -5,6 +5,7 @@ SELECT
     template.id AS template_id,
     template.name AS template_name,
     template.code AS template_code,
+    template.serial_pattern AS template_serial_pattern,
     serial,
     application.name,
     user_id,

--- a/database/insertData/_helpers/core_mutations.js
+++ b/database/insertData/_helpers/core_mutations.js
@@ -3,23 +3,26 @@ GraphQL Fragment - CORE ACTIONS
   - common Actions for all templates
 */
 exports.coreActions = `
-    # ON_APPLICATION_CREATE
-    # change status to DRAFT
+    # ON_APPLICATION_CREATE    
     # generate serial
     # generate initial name
+    # change status to DRAFT
     {
         actionCode: "generateTextString"
         sequence: 1
         trigger: ON_APPLICATION_CREATE
         parameterQueries: {
-          pattern: "S-[A-Z]{3}-<+dddd>"
+          pattern: {
+            operator: "objectProperties"
+            children: [ "applicationData.templateSerialPattern.pattern" ]
+          }
           counterName: {
             operator: "objectProperties"
-            children: [ "applicationData.templateCode" ]
+            children: [ "applicationData.templateSerialPattern.counterName" ]
           }
-          counterInit: 100
-          customFields: {
-            # TBD
+          counterInit: {
+            operator: "objectProperties"
+            children: [ "applicationData.templateSerialPattern.counterInit", 1 ]
           }
           updateRecord: true
           fieldName: "serial"

--- a/database/insertData/laos/02_template_userRegistration.js
+++ b/database/insertData/laos/02_template_userRegistration.js
@@ -467,7 +467,7 @@ exports.queries = [
               }
               {
                 actionCode: "incrementStage"
-                sequence: 1
+                sequence: 3
                 trigger: ON_APPLICATION_CREATE
               }
               {

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -258,6 +258,7 @@ class PostgresDB {
       template_id as "templateId",
       template_name as "templateName",
       template_code as "templateCode",
+      template_serial_pattern as "templateSerialPattern",
       stage_id as "stageId", stage_number as "stageNumber", stage,
       stage_history_id as "stageHistoryId",
       stage_history_time_created as "stageHistoryTimeCreated",

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -515,6 +515,7 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -2742,6 +2743,7 @@ export type ApplicationStageStatusAll = {
   templateId?: Maybe<Scalars['Int']>;
   templateName?: Maybe<Scalars['String']>;
   templateCode?: Maybe<Scalars['String']>;
+  templateSerialPattern?: Maybe<Scalars['JSON']>;
   serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   userId?: Maybe<Scalars['Int']>;
@@ -2773,6 +2775,8 @@ export type ApplicationStageStatusAllCondition = {
   templateName?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `templateCode` field. */
   templateCode?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `templateSerialPattern` field. */
+  templateSerialPattern?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `serial` field. */
   serial?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `name` field. */
@@ -2817,6 +2821,8 @@ export type ApplicationStageStatusAllFilter = {
   templateName?: Maybe<StringFilter>;
   /** Filter by the object’s `templateCode` field. */
   templateCode?: Maybe<StringFilter>;
+  /** Filter by the object’s `templateSerialPattern` field. */
+  templateSerialPattern?: Maybe<JsonFilter>;
   /** Filter by the object’s `serial` field. */
   serial?: Maybe<StringFilter>;
   /** Filter by the object’s `name` field. */
@@ -2890,6 +2896,8 @@ export enum ApplicationStageStatusAllsOrderBy {
   TemplateNameDesc = 'TEMPLATE_NAME_DESC',
   TemplateCodeAsc = 'TEMPLATE_CODE_ASC',
   TemplateCodeDesc = 'TEMPLATE_CODE_DESC',
+  TemplateSerialPatternAsc = 'TEMPLATE_SERIAL_PATTERN_ASC',
+  TemplateSerialPatternDesc = 'TEMPLATE_SERIAL_PATTERN_DESC',
   SerialAsc = 'SERIAL_ASC',
   SerialDesc = 'SERIAL_DESC',
   NameAsc = 'NAME_ASC',
@@ -2930,6 +2938,7 @@ export type ApplicationStageStatusLatest = {
   templateId?: Maybe<Scalars['Int']>;
   templateName?: Maybe<Scalars['String']>;
   templateCode?: Maybe<Scalars['String']>;
+  templateSerialPattern?: Maybe<Scalars['JSON']>;
   serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   userId?: Maybe<Scalars['Int']>;
@@ -2961,6 +2970,8 @@ export type ApplicationStageStatusLatestCondition = {
   templateName?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `templateCode` field. */
   templateCode?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `templateSerialPattern` field. */
+  templateSerialPattern?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `serial` field. */
   serial?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `name` field. */
@@ -3005,6 +3016,8 @@ export type ApplicationStageStatusLatestFilter = {
   templateName?: Maybe<StringFilter>;
   /** Filter by the object’s `templateCode` field. */
   templateCode?: Maybe<StringFilter>;
+  /** Filter by the object’s `templateSerialPattern` field. */
+  templateSerialPattern?: Maybe<JsonFilter>;
   /** Filter by the object’s `serial` field. */
   serial?: Maybe<StringFilter>;
   /** Filter by the object’s `name` field. */
@@ -3078,6 +3091,8 @@ export enum ApplicationStageStatusLatestsOrderBy {
   TemplateNameDesc = 'TEMPLATE_NAME_DESC',
   TemplateCodeAsc = 'TEMPLATE_CODE_ASC',
   TemplateCodeDesc = 'TEMPLATE_CODE_DESC',
+  TemplateSerialPatternAsc = 'TEMPLATE_SERIAL_PATTERN_ASC',
+  TemplateSerialPatternDesc = 'TEMPLATE_SERIAL_PATTERN_DESC',
   SerialAsc = 'SERIAL_ASC',
   SerialDesc = 'SERIAL_DESC',
   NameAsc = 'NAME_ASC',
@@ -3440,6 +3455,7 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -16581,6 +16597,7 @@ export type ReviewAssignmentTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -19304,6 +19321,7 @@ export type Template = Node & {
   id: Scalars['Int'];
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -19649,6 +19667,7 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -19858,6 +19877,8 @@ export type TemplateCondition = {
   name?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `code` field. */
   code?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `serialPattern` field. */
+  serialPattern?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `isLinear` field. */
   isLinear?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `startMessage` field. */
@@ -20436,6 +20457,8 @@ export type TemplateFilter = {
   name?: Maybe<StringFilter>;
   /** Filter by the object’s `code` field. */
   code?: Maybe<StringFilter>;
+  /** Filter by the object’s `serialPattern` field. */
+  serialPattern?: Maybe<JsonFilter>;
   /** Filter by the object’s `isLinear` field. */
   isLinear?: Maybe<BooleanFilter>;
   /** Filter by the object’s `startMessage` field. */
@@ -20756,6 +20779,7 @@ export type TemplateFilterJoinTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -20787,6 +20811,7 @@ export type TemplateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -20957,6 +20982,7 @@ export type TemplatePatch = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -21275,6 +21301,7 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -21582,6 +21609,7 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -21659,6 +21687,8 @@ export enum TemplatesOrderBy {
   NameDesc = 'NAME_DESC',
   CodeAsc = 'CODE_ASC',
   CodeDesc = 'CODE_DESC',
+  SerialPatternAsc = 'SERIAL_PATTERN_ASC',
+  SerialPatternDesc = 'SERIAL_PATTERN_DESC',
   IsLinearAsc = 'IS_LINEAR_ASC',
   IsLinearDesc = 'IS_LINEAR_DESC',
   StartMessageAsc = 'START_MESSAGE_ASC',
@@ -22231,6 +22261,7 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -22392,6 +22423,7 @@ export type TemplateTemplateCategoryIdFkeyTemplateCreateInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26040,6 +26072,7 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26063,6 +26096,7 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26086,6 +26120,7 @@ export type UpdateTemplateOnReviewAssignmentForReviewAssignmentTemplateIdFkeyPat
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26109,6 +26144,7 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26132,6 +26168,7 @@ export type UpdateTemplateOnTemplateFilterJoinForTemplateFilterJoinTemplateIdFke
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26155,6 +26192,7 @@ export type UpdateTemplateOnTemplateForTemplateTemplateCategoryIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26177,6 +26215,7 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26200,6 +26239,7 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -26223,6 +26263,7 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
+  serialPattern?: Maybe<Scalars['JSON']>;
   isLinear?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
@@ -32040,6 +32081,7 @@ export type ApplicationStageStatusAllResolvers<ContextType = any, ParentType ext
   templateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   templateName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   templateCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  templateSerialPattern?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   serial?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   userId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -32078,6 +32120,7 @@ export type ApplicationStageStatusLatestResolvers<ContextType = any, ParentType 
   templateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   templateName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   templateCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  templateSerialPattern?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   serial?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   userId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -34109,6 +34152,7 @@ export type TemplateResolvers<ContextType = any, ParentType extends ResolversPar
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  serialPattern?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   isLinear?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   startMessage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['TemplateStatus']>, ParentType, ContextType>;


### PR DESCRIPTION
Proposed way of defining different serial formats (and counters) for each template, as briefly discussed [here](https://github.com/openmsupply/application-manager-server/pull/454#discussion_r670839268) and with @andreievg IRL earlier in the week.

### Summary

- add `serial_pattern` field to "template" table, in jsonb format, with a default specified (GEN-XXX-0001)
- get "templateSerialPattern" as part of "applicationData" (via `application_stage_status_all`)
- actions in core_mutations for ON_APPLICATION_CREATE updated to pass these values through to `generateTextString` for creating the serial

Let me know what you think, or if you have alternative suggestions. Bear in mind that if a particular template requires a more complex serial than can be defined in "serial_pattern", we can add another action to that template that immediately overwrites the one generated in core actions.