### PR TITLE
#439 (Part 1) getTemplateData

### DIFF
--- a/plugins/action_generate_document/src/generateDoc.ts
+++ b/plugins/action_generate_document/src/generateDoc.ts
@@ -8,8 +8,8 @@ const generateDoc: ActionPluginType = async ({
   // DBConnect,
   outputCumulative,
 }) => {
-  const { docTemplateId } = parameters
-  const data = parameters?.data ?? { ...applicationData, ...outputCumulative }
+  const { docTemplateId, additionalData } = parameters
+  const data = parameters?.data ?? { ...applicationData, ...outputCumulative, ...additionalData }
   const userId = parameters?.userId ?? applicationData?.userId
   const applicationSerial = parameters?.applicationSerial ?? applicationData?.applicationSerial
 

--- a/src/components/actions/getApplicationData.ts
+++ b/src/components/actions/getApplicationData.ts
@@ -3,13 +3,14 @@ import DBConnect from '../databaseConnect'
 import { BasicObject } from '@openmsupply/expression-evaluator/lib/types'
 import { getAppEntryPointDir } from '../utilityFunctions'
 import config from '../../config'
+import { Template } from '../../generated/graphql'
 
 // Add more data (such as org/review, etc.) here as required
 export const getApplicationData = async (input: {
   payload?: ActionPayload
   applicationId?: number
   reviewId?: number
-  templateData?: any
+  templateData?: Template
 }): Promise<ActionApplicationData> => {
   // Requires either application OR trigger_payload, so throw error if neither provided
   if (!input?.payload?.trigger_payload && !input?.applicationId)

--- a/src/components/actions/getApplicationData.ts
+++ b/src/components/actions/getApplicationData.ts
@@ -9,6 +9,7 @@ export const getApplicationData = async (input: {
   payload?: ActionPayload
   applicationId?: number
   reviewId?: number
+  templateData?: any
 }): Promise<ActionApplicationData> => {
   // Requires either application OR trigger_payload, so throw error if neither provided
   if (!input?.payload?.trigger_payload && !input?.applicationId)
@@ -47,6 +48,9 @@ export const getApplicationData = async (input: {
       }
     : {}
 
+  const templateData =
+    input?.templateData || (await DBConnect.getTemplateData(applicationData.templateId))
+
   const environmentData = {
     appRootFolder: getAppEntryPointDir(),
     filesFolder: config.filesFolder,
@@ -56,6 +60,7 @@ export const getApplicationData = async (input: {
     action_payload: input?.payload,
     ...applicationData,
     ...userData,
+    templateData,
     responses: responseData,
     reviewData,
     environmentData,

--- a/src/components/actions/triggersAndActions.ts
+++ b/src/components/actions/triggersAndActions.ts
@@ -99,6 +99,9 @@ export async function processTrigger(payload: TriggerPayload) {
 
   const templateId = await DBConnect.getTemplateIdFromTrigger(payload.table, payload.record_id)
 
+  // Get all template data
+  const templateData = await DBConnect.getTemplateData(templateId)
+
   // Get Actions from matching Template
   const actions = await DBConnect.getActionsByTemplateId(templateId, trigger)
 
@@ -160,6 +163,7 @@ export async function processTrigger(payload: TriggerPayload) {
       }
       const result = await executeAction(actionPayload, actionLibrary, {
         outputCumulative,
+        templateData,
       })
       outputCumulative = { ...outputCumulative, ...result.output }
       // Enable next line to inspect outputCumulative:
@@ -197,7 +201,10 @@ export async function executeAction(
   additionalObjects: any = {}
 ): Promise<ActionQueueExecutePayload> {
   // Get fresh applicationData for each Action
-  const applicationData = await getApplicationData({ payload })
+  const applicationData = await getApplicationData({
+    payload,
+    templateData: additionalObjects?.templateData,
+  })
 
   // Enable next line to inspect applicationData:
   // console.log('ApplicationData: ', applicationData)

--- a/src/components/databaseConnect.ts
+++ b/src/components/databaseConnect.ts
@@ -132,6 +132,8 @@ class DBConnect {
   public gqlQuery = GraphQLdb.gqlQuery
 
   public getReviewData = GraphQLdb.getReviewData
+
+  public getTemplateData = GraphQLdb.getTemplateData
 }
 
 const dbConnectInstance = DBConnect.Instance

--- a/src/components/graphQLConnect.ts
+++ b/src/components/graphQLConnect.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch'
 import config from '../config'
 import { getAdminJWT } from './permissions/loginHelpers'
+import { Template } from '../generated/graphql'
 
 const endpoint = config.graphQLendpoint
 
@@ -71,7 +72,7 @@ class GraphQLdb {
     // Not implemented yet -- needs more data in DB
   }
 
-  public getTemplateData = async (templateId: number) => {
+  public getTemplateData = async (templateId: number): Promise<Template> => {
     const data = await this.gqlQuery(
       `
         query getTemplateData($templateId: Int!) {

--- a/src/components/graphQLConnect.ts
+++ b/src/components/graphQLConnect.ts
@@ -70,6 +70,92 @@ class GraphQLdb {
     }
     // Not implemented yet -- needs more data in DB
   }
+
+  public getTemplateData = async (templateId: number) => {
+    const data = await this.gqlQuery(
+      `
+        query getTemplateData($templateId: Int!) {
+          template(id: $templateId) {
+            id
+            code
+            name
+            status
+            isLinear
+            startMessage
+            submissionMessage
+            version
+            versionTimestamp
+            templateCategory {
+              code
+              id
+              title
+            }
+            templateSections {
+              nodes {
+                id
+                code
+                index
+                title
+                templateElementsBySectionId {
+                  nodes {
+                    id
+                    code
+                    category
+                    elementTypePluginCode
+                    title
+                    index
+                    defaultValue      
+                    helpText
+                    visibilityCondition
+                    isEditable
+                    isRequired
+                    validation
+                    validationMessage
+                    parameters
+                  }
+                }
+              }
+            }
+            templateStages {
+              nodes {
+                id
+                number
+                title
+                description
+                colour
+              }
+            }
+            templateActions {
+              nodes {
+                id
+                actionCode
+                sequence
+                condition
+                parameterQueries
+                trigger
+              }
+            }
+            templatePermissions {
+              nodes {
+                id
+                permissionName {
+                  name
+                  id
+                }
+                stageNumber
+                levelNumber
+                allowedSections
+                canSelfAssign        
+                restrictions
+              }
+            }
+          }
+        }      
+      `,
+      { templateId }
+    )
+    return data.template
+  }
 }
 
 const graphqlDBInstance = GraphQLdb.Instance


### PR DESCRIPTION
This is just the preliminary stuff that needs to happen before I can really do #439 properly.

In Summary, this adds "templateData" to applicationData, so we can have access to all questions, etc in Actions. Just wanted to PR this first to check that we were all happy with this approach.

See [this comment](https://github.com/openmsupply/application-manager-server/issues/439#issuecomment-883848014) for context.

### In Summary:

- a "getTemplateData" query runs at the top of each Trigger (in `processTrigger`)
- this is passed to `getApplicationData`, and embedded into the resulting `applicationData` object (so it doesn't need to be re-queried between multiple actions in a sequence)
- if `templateData` is NOT passed to `getApplicationData` (e.g. if running from endpoint, say), it will be re-queried.

The query is done with GraphQL (using GraphQLConnect) -- are we happy with the shape of the resulting object?