### PR TITLE
#426(2) core action for serial generation

### DIFF
--- a/database/insertData/_common/03_template_G_userEdit.js
+++ b/database/insertData/_common/03_template_G_userEdit.js
@@ -310,6 +310,7 @@ exports.queries = [
                       # TBD
                     }
                     updateRecord: true
+                    table: "application"
                     fieldName: "serial"
                   }
               }
@@ -324,6 +325,8 @@ exports.queries = [
                       serial: "applicationData.applicationSerial"
                     }
                     updateRecord: true
+                    table: "application"
+                    fieldName: "name"
                   }
               }
               {

--- a/database/insertData/_common/03_template_G_userEdit.js
+++ b/database/insertData/_common/03_template_G_userEdit.js
@@ -300,7 +300,7 @@ exports.queries = [
                   sequence: 1
                   trigger: ON_APPLICATION_CREATE
                   parameterQueries: {
-                    pattern: "U-[A-Z]{3}-<+dddd>"
+                    pattern: "UE-[A-Z]{3}-<+dddd>"
                     counterName: {
                       operator: "objectProperties"
                       children: [ "applicationData.templateCode" ]
@@ -331,7 +331,7 @@ exports.queries = [
               }
               {
                 actionCode: "incrementStage"
-                sequence: 1
+                sequence: 3
                 trigger: ON_APPLICATION_CREATE
               }
               {

--- a/database/insertData/_common/03_template_G_userEdit.js
+++ b/database/insertData/_common/03_template_G_userEdit.js
@@ -310,7 +310,7 @@ exports.queries = [
                       # TBD
                     }
                     updateRecord: true
-                    table: "application"
+                    tableName: "application"
                     fieldName: "serial"
                   }
               }
@@ -325,7 +325,7 @@ exports.queries = [
                       serial: "applicationData.applicationSerial"
                     }
                     updateRecord: true
-                    table: "application"
+                    tableName: "application"
                     fieldName: "name"
                   }
               }

--- a/database/insertData/_helpers/core_mutations.js
+++ b/database/insertData/_helpers/core_mutations.js
@@ -19,7 +19,7 @@ exports.coreActions = `
           }
           # counterInit: 100
           updateRecord: true
-          table: "application"
+          tableName: "application"
           fieldName: "serial"
         }
     }
@@ -34,7 +34,7 @@ exports.coreActions = `
             serial: "applicationData.applicationSerial"
           }
           updateRecord: true
-          table: "application"
+          tableName: "application"
           fieldName: "name"
         }
     }

--- a/database/insertData/_helpers/core_mutations.js
+++ b/database/insertData/_helpers/core_mutations.js
@@ -17,11 +17,9 @@ exports.coreActions = `
             operator: "objectProperties"
             children: [ "applicationData.templateCode" ]
           }
-          counterInit: 100
-          customFields: {
-            # TBD
-          }
+          # counterInit: 100
           updateRecord: true
+          table: "application"
           fieldName: "serial"
         }
     }
@@ -36,6 +34,8 @@ exports.coreActions = `
             serial: "applicationData.applicationSerial"
           }
           updateRecord: true
+          table: "application"
+          fieldName: "name"
         }
     }
     {

--- a/database/insertData/dev/02_template_userRegistration.js
+++ b/database/insertData/dev/02_template_userRegistration.js
@@ -184,7 +184,7 @@ exports.queries = [
                       # TBD
                     }
                     updateRecord: true
-                    table: "application"
+                    tableName: "application"
                     fieldName: "serial"
                   }
               }
@@ -199,7 +199,7 @@ exports.queries = [
                       serial: "applicationData.applicationSerial"
                     }
                     updateRecord: true
-                    table: "application"
+                    tableName: "application"
                     fieldName: "name"
                   }
               }

--- a/database/insertData/dev/02_template_userRegistration.js
+++ b/database/insertData/dev/02_template_userRegistration.js
@@ -174,7 +174,7 @@ exports.queries = [
                   sequence: 1
                   trigger: ON_APPLICATION_CREATE
                   parameterQueries: {
-                    pattern: "U-[A-Z]{3}-<+dddd>"
+                    pattern: "UR-[A-Z]{3}-<+dddd>"
                     counterName: {
                       operator: "objectProperties"
                       children: [ "applicationData.templateCode" ]
@@ -184,6 +184,7 @@ exports.queries = [
                       # TBD
                     }
                     updateRecord: true
+                    table: "application"
                     fieldName: "serial"
                   }
               }
@@ -198,6 +199,8 @@ exports.queries = [
                       serial: "applicationData.applicationSerial"
                     }
                     updateRecord: true
+                    table: "application"
+                    fieldName: "name"
                   }
               }
               {

--- a/database/insertData/dev/03_template_D_basicReviewTesting.js
+++ b/database/insertData/dev/03_template_D_basicReviewTesting.js
@@ -278,7 +278,7 @@ exports.queries = [
                     productName: "applicationData.responses.Q20.text"
                   }
                   updateRecord: true
-                  table: "application"
+                  tableName: "application"
                   fieldName: "name"
                 }
               }

--- a/database/insertData/dev/03_template_D_basicReviewTesting.js
+++ b/database/insertData/dev/03_template_D_basicReviewTesting.js
@@ -278,6 +278,8 @@ exports.queries = [
                     productName: "applicationData.responses.Q20.text"
                   }
                   updateRecord: true
+                  table: "application"
+                  fieldName: "name"
                 }
               }
             ]

--- a/database/insertData/laos/02_template_userRegistration.js
+++ b/database/insertData/laos/02_template_userRegistration.js
@@ -450,7 +450,7 @@ exports.queries = [
                       # TBD
                     }
                     updateRecord: true
-                    table: "application"
+                    tableName: "application"
                     fieldName: "serial"
                   }
               }
@@ -465,7 +465,7 @@ exports.queries = [
                       serial: "applicationData.applicationSerial"
                     }
                     updateRecord: true
-                    table: "application"
+                    tableName: "application"
                     fieldName: "name"
                   }
               }

--- a/database/insertData/laos/02_template_userRegistration.js
+++ b/database/insertData/laos/02_template_userRegistration.js
@@ -450,6 +450,7 @@ exports.queries = [
                       # TBD
                     }
                     updateRecord: true
+                    table: "application"
                     fieldName: "serial"
                   }
               }
@@ -464,6 +465,8 @@ exports.queries = [
                       serial: "applicationData.applicationSerial"
                     }
                     updateRecord: true
+                    table: "application"
+                    fieldName: "name"
                   }
               }
               {

--- a/documentation/List-of-Action-plugins.md
+++ b/documentation/List-of-Action-plugins.md
@@ -158,8 +158,8 @@ Generates serial numbers or arbitrary text strings (e.g. for application name) u
 | `numberFormat`                           |                   |
 | `fallbackText`                           |                   |
 | `updateRecord` (default `false`)         |                   |
-| `tableName` (default `application`)      |                   |
-| `fieldName` (default `name`)             |                   |
+| `tableName`                              |                   |
+| `fieldName`                              |                   |
 | `matchField` (default `"id"`)            |                   |
 | `matchValue` (default `applicationId`)   |                   |
 | `additionalData`                         |                   |
@@ -229,8 +229,8 @@ The parameters can be considered in two distinct groups -- parameters for defini
 
 This action actually just calls [modifyRecord](#modify-record) to update the database, so the following parameters are the same as for in that action:
 
-- `tableName` (default `application`)
-- `fieldName` (default `name`)
+- `tableName`
+- `fieldName`
 - `matchField` (default `id`)
 - `matchValue` (default `applicationId`)
 
@@ -247,6 +247,7 @@ This action actually just calls [modifyRecord](#modify-record) to update the dat
   }
   counterInit: 100
   updateRecord: true
+  table: "application"
   fieldName: "serial"
 }
 ```
@@ -256,7 +257,7 @@ This generates serial numbers such as:
 `S-ZEH-0101`  
 `S-DXF-0102`
 
-It gets the number from a counter named from the `templateCode` via evaluator expression look-up, starts counting at 100, then saves the generated string to the `serial` field on the `application` table (this is the default table, so doesn't need to be specified explicitly).
+It gets the number from a counter named from the `templateCode` via evaluator expression look-up, starts counting at 100, then saves the generated string to the `serial` field on the `application` table.
 
 2.
 
@@ -268,6 +269,8 @@ It gets the number from a counter named from the `templateCode` via evaluator ex
         productName: "applicationData.responses.Q20.text"
     }
     updateRecord: true
+    table: "application"
+    fieldName: "name"
 }
 ```
 

--- a/documentation/List-of-Action-plugins.md
+++ b/documentation/List-of-Action-plugins.md
@@ -247,7 +247,7 @@ This action actually just calls [modifyRecord](#modify-record) to update the dat
   }
   counterInit: 100
   updateRecord: true
-  table: "application"
+  tableName: "application"
   fieldName: "serial"
 }
 ```
@@ -269,7 +269,7 @@ It gets the number from a counter named from the `templateCode` via evaluator ex
         productName: "applicationData.responses.Q20.text"
     }
     updateRecord: true
-    table: "application"
+    tableName: "application"
     fieldName: "name"
 }
 ```

--- a/plugins/action_generate_text_string/src/generateTextString.ts
+++ b/plugins/action_generate_text_string/src/generateTextString.ts
@@ -20,8 +20,8 @@ async function generateTextString({
     numberFormat,
     fallbackText = 'Missing_data_property',
     updateRecord = false,
-    tableName = 'application',
-    fieldName = 'name',
+    tableName,
+    fieldName,
     matchField = 'id',
     matchValue = applicationData?.applicationId,
   } = parameters


### PR DESCRIPTION
Replaces PR #459, as discussed [here](https://github.com/openmsupply/application-manager-server/pull/459#issuecomment-885342227)

- a core action which generates a very basic serial, but uses the templateCode as the name of its counter
   - when new templates are created/duplicated, core actions are copied, so it's easy for template creators to change the generate serial action (in Template Builder) if they want to make a more specific serial generating pattern
- remove default "table" and "field" values from "generateTextStrings", as per suggestion (and add them to templates accordingly) 