### PR TITLE
#690F fix review assignments duplicated for level 1 after LOQ is submitted

### DIFF
--- a/database/insertData/dev/06_applications_D_reviewTest.js
+++ b/database/insertData/dev/06_applications_D_reviewTest.js
@@ -231,7 +231,7 @@ exports.queries = [
       }
     }
   }`,
-  // Application 2 for Review Testing - on Stage 1 of 3
+  // Application 2 for Review Testing - on Stage 1 of 3 - LOQ to Applicant
   `mutation ReviewTestApplication2 {
     createApplication(
       input: {
@@ -458,7 +458,7 @@ exports.queries = [
       }
     }
   }`,
-  // Application 3 for Review Testing
+  // Application 3 for Review Testing 
   `mutation ReviewTestApplication3 {
     createApplication(
       input: {
@@ -639,7 +639,7 @@ exports.queries = [
       }
     }
   }`,
-  // Application 4 for Review Testing -- on Stage 2 during consolidation (Level 2) 
+  // Application 4 for Review Testing -- on Stage 2 (Level 1) 
   `mutation ReviewTestApplication4 {
     createApplication(
       input: {

--- a/database/insertData/dev/07_review_assignments.js
+++ b/database/insertData/dev/07_review_assignments.js
@@ -1075,7 +1075,7 @@ exports.queries = [
       }
     }
   }`,
-  // -- Reviewer 2 in Stage 2, Lvl 1 (section 2) = DRAFT (Partial stage 2 not submitted)
+  // -- Reviewer 2 in Stage 2, Lvl 1 (section 2) = ASSIGNED (Partial stage 2 not started)
   `mutation {
     createReviewAssignment(
       input: {
@@ -1099,68 +1099,6 @@ exports.queries = [
               { id: 3018, templateElementId: 4012 }
               { id: 3019, templateElementId: 4013 }
             ]
-          }
-          reviewsUsingId: {
-            create: {
-              id: 6004
-              reviewResponsesUsingId: {
-                create: [
-                  {
-                    applicationResponseId: 4025
-                    reviewQuestionAssignmentId: 3015
-                    status: DRAFT
-                    decision: APPROVE
-                    stageNumber: 2
-                    timeCreated: "2021-05-19T00:00:00Z"
-                    timeUpdated: "2021-05-19T15:00:01Z"
-                  }
-                  {
-                    applicationResponseId: 4026
-                    reviewQuestionAssignmentId: 3016
-                    status: DRAFT
-                    decision: APPROVE
-                    stageNumber: 2
-                    timeCreated: "2021-05-19T00:00:00Z"
-                    timeUpdated: "2021-05-19T15:00:02Z"
-                  }
-                  {
-                    applicationResponseId: 4027
-                    reviewQuestionAssignmentId: 3017
-                    status: DRAFT
-                    decision: APPROVE
-                    stageNumber: 2
-                    timeCreated: "2021-05-19T00:00:00Z"
-                    timeUpdated: "2021-05-19T15:00:03Z"
-                  }
-                  {
-                    applicationResponseId: 4028
-                    reviewQuestionAssignmentId: 3018
-                    status: DRAFT
-                    decision: APPROVE
-                    stageNumber: 2
-                    timeCreated: "2021-05-19T00:00:00Z"
-                    timeUpdated: "2021-05-19T15:00:04Z"
-                  }
-                  {
-                    applicationResponseId: 4029
-                    reviewQuestionAssignmentId: 3019
-                    status: DRAFT
-                    decision: APPROVE
-                    stageNumber: 2
-                    timeCreated: "2021-05-19T00:00:00Z"
-                    timeUpdated: "2021-05-19T15:00:05Z"
-                  }
-                ]
-              }
-              reviewStatusHistoriesUsingId: {
-                create: [
-                  { status: DRAFT, isCurrent: true, timeCreated: "2021-05-19T00:00:00Z" }
-                ]
-              }
-              reviewDecisionsUsingId: {
-                create: [{ decision: NO_DECISION }]
-              }
-            }
           }
         }
       }
@@ -2248,7 +2186,7 @@ exports.queries = [
     }
   }`,
   // Assign test reviews of Application 6 (serial: ABC456) of Review Testing (template)
-  // Reviewer 1 in Stage 1 (All sectios) = NOT STARTED
+  // Reviewer 1 in Stage 1 (All sectios) = ASSIGNED (Not started)
   `mutation {
     createReviewAssignment(
       input: {

--- a/database/insertData/dev/07_review_assignments.js
+++ b/database/insertData/dev/07_review_assignments.js
@@ -1507,7 +1507,7 @@ exports.queries = [
       }
     }
   }`,
-  // -- Reviewer 1 in Stage 2, Lvl 1 (section 1) = DECLINED - Suggest LOQ
+  // -- Reviewer 1 in Stage 2, Lvl 1 (section 1) = DECLINED - In progress
   `mutation {
     createReviewAssignment(
       input: {
@@ -1539,57 +1539,52 @@ exports.queries = [
                     id: 5000
                     applicationResponseId: 4150
                     reviewQuestionAssignmentId: 5010
-                    status: SUBMITTED
+                    status: DRAFT
                     decision: APPROVE
                     stageNumber: 2
                     timeCreated: "2021-07-10T00:00:00Z"
                     timeUpdated: "2021-07-10T10:00:01Z"
-                    timeSubmitted: "2021-07-10T10:00:00Z"
                   }
                   {
                     id: 5001
                     applicationResponseId: 4151
                     reviewQuestionAssignmentId: 5011
-                    status: SUBMITTED
+                    status: DRAFT
                     decision: APPROVE
                     stageNumber: 2
                     timeCreated: "2021-07-10T00:00:00Z"
                     timeUpdated: "2021-07-10T10:00:02Z"
-                    timeSubmitted: "2021-07-10T10:00:00Z"
                   }
                   {
                     id: 5002
                     applicationResponseId: 4152
                     reviewQuestionAssignmentId: 5012
-                    status: SUBMITTED
+                    status: DRAFT
                     decision: APPROVE
                     stageNumber: 2
                     timeCreated: "2021-07-10T00:00:00Z"
                     timeUpdated: "2021-07-10T10:00:03Z"
-                    timeSubmitted: "2021-07-10T10:00:00Z"
                   }
                   {
                     id: 5003
                     applicationResponseId: 4153
                     reviewQuestionAssignmentId: 5013
-                    status: SUBMITTED
+                    status: DRAFT
                     decision: APPROVE
                     stageNumber: 2
                     timeCreated: "2021-07-10T00:00:00Z"
                     timeUpdated: "2021-07-10T10:00:04Z"
-                    timeSubmitted: "2021-07-10T10:00:00Z"
                   }
                   {
                     id: 5004
                     applicationResponseId: 4154
                     reviewQuestionAssignmentId: 5014
-                    status: SUBMITTED
+                    status: DRAFT
                     decision: DECLINE
                     comment: "Country name spelling wrong"
                     stageNumber: 2
                     timeCreated: "2021-07-10T00:00:00Z"
                     timeUpdated: "2021-07-10T10:00:05Z"
-                    timeSubmitted: "2021-07-10T10:00:00Z"
                   }
                 ]
               }
@@ -1597,21 +1592,13 @@ exports.queries = [
                 create: [
                   { 
                     status: DRAFT
-                    isCurrent: false
-                    timeCreated: "2021-07-10T00:00:00Z"
-                  }
-                  {
-                    status: SUBMITTED
                     isCurrent: true
-                    timeCreated: "2021-07-10T10:00:00Z"
+                    timeCreated: "2021-07-10T00:00:00Z"
                   }
                 ]
               }
               reviewDecisionsUsingId: {
-                create: { 
-                  decision: LIST_OF_QUESTIONS 
-                  comment: "Suggestion by Reviewer 1 to reply to applicant with LOQ"
-                }
+                create: { decision: NO_DECISION }
               }
             }
           }
@@ -1667,158 +1654,6 @@ exports.queries = [
       reviewAssignment {
         application {
           name
-        }
-      }
-    }
-  }`,
-  // -- Consolidator 1 Lvl 2 - Stage 2 = NOT AVAILABLE (not assignable for this consolidator)
-  `mutation {
-    createReviewAssignment(
-      input: {
-        reviewAssignment: {
-          id: 1033
-          applicationId: 4003
-          stageId: 6
-          stageNumber: 2
-          levelNumber: 2
-          isLastLevel: true
-          userToReviewerId: {
-            connectByUsername: { username: "testConsolidator1" }
-          }
-          status: SELF_ASSIGNED_BY_ANOTHER
-          reviewQuestionAssignmentsUsingId: {
-            create: [
-              { id: 5022, templateElementId: 4001 }
-              { id: 5023, templateElementId: 4002 }
-              { id: 5024, templateElementId: 4003 }
-              { id: 5025, templateElementId: 4005 }
-              { id: 5026, templateElementId: 4006 }
-              { id: 5027, templateElementId: 4008 }
-              { id: 5028, templateElementId: 4009 }
-              { id: 5029, templateElementId: 4011 }
-              { id: 5030, templateElementId: 4012 }
-            ]
-          }
-        }
-      }
-    ) {
-      reviewer {
-        username
-      }
-      reviewAssignment {
-        application {
-          name
-        }
-      }
-    }
-  }`,
-  // -- Consolidator 2 Lvl 2 - Stage 2 = DRAFT (AGREE with Reviewer 1)
-  `mutation {
-    createReviewAssignment(
-      input: {
-        reviewAssignment: {
-          id: 1034
-          applicationId: 4003
-          stageId: 6
-          stageNumber: 2
-          levelNumber: 2
-          isLastLevel: true
-          userToReviewerId: {
-            connectByUsername: { username: "testConsolidator2" }
-          }
-          status: ASSIGNED
-          reviewQuestionAssignmentsUsingId: {
-            create: [
-              { id: 5033, templateElementId: 4001 }
-              { id: 5034, templateElementId: 4002 }
-              { id: 5035, templateElementId: 4003 }
-              { id: 5036, templateElementId: 4005 }
-              { id: 5037, templateElementId: 4006 }
-            ]
-          }
-          reviewsUsingId: {
-            create: {
-              id: 7004
-              reviewResponsesUsingId: {
-                create: [
-                  {
-                    applicationResponseId: 4150
-                    reviewQuestionAssignmentId: 5033
-                    reviewResponseLinkId: 5000
-                    status: DRAFT
-                    decision: AGREE
-                    stageNumber: 2
-                    timeCreated: "2021-07-20T00:00:00Z"
-                    timeUpdated: "2021-07-20T10:00:01Z"
-                  }
-                  {
-                    applicationResponseId: 4151
-                    reviewQuestionAssignmentId: 5034
-                    reviewResponseLinkId: 5001
-                    status: DRAFT
-                    decision: AGREE
-                    stageNumber: 2
-                    timeCreated: "2021-07-20T00:00:00Z"
-                    timeUpdated: "2021-07-20T10:00:02Z"
-                  }
-                  {
-                    applicationResponseId: 4152
-                    reviewQuestionAssignmentId: 5035
-                    reviewResponseLinkId: 5002
-                    status: DRAFT
-                    decision: AGREE
-                    stageNumber: 2
-                    timeCreated: "2021-07-20T00:00:00Z"
-                    timeUpdated: "2021-07-20T10:00:03Z"
-                  }
-                  {
-                    applicationResponseId: 4153
-                    reviewQuestionAssignmentId: 5036
-                    reviewResponseLinkId: 5003
-                    status: DRAFT
-                    decision: AGREE
-                    stageNumber: 2
-                    timeCreated: "2021-07-20T00:00:00Z"
-                    timeUpdated: "2021-07-20T10:00:04Z"
-                  }
-                  {
-                    applicationResponseId: 4154
-                    reviewQuestionAssignmentId: 5037
-                    reviewResponseLinkId: 5004
-                    status: DRAFT
-                    decision: AGREE
-                    stageNumber: 2
-                    timeCreated: "2021-07-20T00:00:00Z"
-                    timeUpdated: "2021-07-20T10:00:05Z"
-                  }
-                ]
-              }
-              reviewStatusHistoriesUsingId: {
-                create: [
-                  {
-                    status: DRAFT
-                    isCurrent: true
-                    timeCreated: "2021-06-10T10:00:00Z"
-                  }
-                ]
-              }
-              reviewDecisionsUsingId: {
-                create: { decision: NO_DECISION }
-              }
-            }
-          }
-        }
-      }
-    ) {
-      reviewAssignment {
-        application {
-          name
-        }
-        stage {
-          id
-        }
-        reviewer{
-          username
         }
       }
     }

--- a/plugins/action_generate_review_assignment_records/src/databaseMethods.ts
+++ b/plugins/action_generate_review_assignment_records/src/databaseMethods.ts
@@ -60,7 +60,7 @@ const databaseMethods = (DBConnect: any) => ({
         text,
         values: [applicationId, stageNumber, levelNumber, reviewerId],
       })
-      return result.rows
+      return result.rows.length > 0
     } catch (err) {
       console.log(err.message)
       throw err

--- a/plugins/action_generate_review_assignment_records/src/databaseMethods.ts
+++ b/plugins/action_generate_review_assignment_records/src/databaseMethods.ts
@@ -45,6 +45,27 @@ const databaseMethods = (DBConnect: any) => ({
       throw err
     }
   },
+  checkExistingReviewAssignment: async (reviewAssigment: ReviewAssignment) => {
+    const { applicationId, stageNumber, levelNumber, reviewerId } = reviewAssigment
+
+    const text = `
+      SELECT * FROM review_assignment 
+      WHERE application_id = $1
+      AND stage_number = $2
+      AND level_number = $3
+      AND reviewer_id = $4
+    `
+    try {
+      const result = await DBConnect.query({
+        text,
+        values: [applicationId, stageNumber, levelNumber, reviewerId],
+      })
+      return result.rows
+    } catch (err) {
+      console.log(err.message)
+      throw err
+    }
+  },
   addReviewAssignments: async (reviewAssignments: ReviewAssignment[]) => {
     const reviewAssignmentIds = []
     for (const reviewAssignment of reviewAssignments) {

--- a/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.test.ts
+++ b/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.test.ts
@@ -31,12 +31,13 @@ test('Test: Submit Application ID#4001 - Stage 1 (Last level) - reviewAssignment
     expect(clearResult(result)).toEqual({
       status: ActionQueueStatus.Success,
       error_log: '',
-      output: {},
+      output: {
+        reviewAssignments: [],
+      },
     })
   })
 })
 
-// Simulate application submissions:
 describe('Submit new application on first stage to generate reviewAssignments on Stage 1', () => {
   // Setup database
   beforeAll(async (done) => {
@@ -252,8 +253,6 @@ describe('Re-submit new application on second stage to generate new reviewAssign
   })
 })
 
-// Recreated test case for First Review submission (Stage 1 - generate assignment for Stage 2)
-
 // Simulate review submission:
 
 test('Test: Submit Review ID#7002 for Application ID#4003 - Stage 2 Lvl 1 to generate level 2 assignments', () => {
@@ -308,14 +307,14 @@ describe('Create new Review to simulate application moving to last stage (Final 
   beforeAll(async (done) => {
     await DBConnect.query({
       text: `
-      INSERT INTO public.review (id, application_id, review_assignment_id)
-        VALUES (8000, 4004, 10)
+      INSERT INTO public.review (id, review_assignment_id)
+        VALUES (8000, 10);
       INSERT INTO public.review_decision (id, decision, review_id)
         VALUES (DEFAULT, 'NON_CONFORM', 8000);
       INSERT INTO public.review_status_history (id, review_id, status)
-        VALUES (DEFAULT, 7004, 'SUBMITTED');
+        VALUES (DEFAULT, 8000, 'SUBMITTED');
       INSERT INTO public.application_stage_history (id, application_id, stage_id, is_current)
-        VALUES (2000, 4004, 7, 'True');
+        VALUES (2000, 4003, 7, 'True');
       INSERT INTO public.application_status_history (id, application_stage_history_id, status, is_current)
         VALUES (DEFAULT, 2000, 'SUBMITTED', 'True');
       `,
@@ -324,9 +323,9 @@ describe('Create new Review to simulate application moving to last stage (Final 
     done()
   })
 
-  test('Submit Review ID#7003 for Application ID#4004 - Stage 2 Lvl 2 to create assignments for Stage 3 (Last Stage) - Final Decision', () => {
+  test('Submit Review ID#8000 for Application ID#4004 - Stage 2 Lvl 2 to create assignments for Stage 3 (Last Stage) - Final Decision', () => {
     return generateReviewAssignments({
-      parameters: { templateId: 4, applicationId: 4004, reviewId: 7004 }, // stageNumber: 2, stageId: 7, levels: 2
+      parameters: { templateId: 4, applicationId: 4003, reviewId: 8000 }, // stageNumber: 2, stageId: 7, levels: 2
       DBConnect,
     }).then((result: any) => {
       expect(clearResult(result)).toEqual({
@@ -341,7 +340,7 @@ describe('Create new Review to simulate application moving to last stage (Final 
               stageNumber: 3,
               levelNumber: 1,
               status: ReviewAssignmentStatus.Assigned,
-              applicationId: 4004,
+              applicationId: 4003,
               allowedSections: null,
               isLastLevel: true,
               isLastStage: true,
@@ -354,7 +353,7 @@ describe('Create new Review to simulate application moving to last stage (Final 
               stageNumber: 3,
               levelNumber: 1,
               status: ReviewAssignmentStatus.Assigned,
-              applicationId: 4004,
+              applicationId: 4003,
               allowedSections: null,
               isLastLevel: true,
               isLastStage: true,

--- a/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.test.ts
+++ b/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.test.ts
@@ -21,7 +21,8 @@ const clearResult = (result: any) => ({
 
 // Simulate application submission:
 
-test('Test: Submit Application ID#4001 - Stage 1 (Last level)', () => {
+// Show that reviewAssignments don't get created if already existing
+test('Test: Submit Application ID#4001 - Stage 1 (Last level) - reviewAssignments already existing', () => {
   //stageNumber: 1, stageId: 5, levels: 1
   return generateReviewAssignments({
     parameters: { applicationId: 4001 },
@@ -30,185 +31,234 @@ test('Test: Submit Application ID#4001 - Stage 1 (Last level)', () => {
     expect(clearResult(result)).toEqual({
       status: ActionQueueStatus.Success,
       error_log: '',
-      output: {
-        reviewAssignments: [
-          {
-            reviewerId: 2,
-            orgId: null,
-            stageId: 5,
-            stageNumber: 1,
-            status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4001,
-            allowedSections: null,
-            levelNumber: 1,
-            isLastLevel: true,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-          {
-            reviewerId: 3,
-            orgId: null,
-            stageId: 5,
-            stageNumber: 1,
-            status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4001,
-            allowedSections: null,
-            levelNumber: 1,
-            isLastLevel: true,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-          {
-            reviewerId: 4,
-            orgId: null,
-            stageId: 5,
-            stageNumber: 1,
-            status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4001,
-            allowedSections: null,
-            levelNumber: 1,
-            isLastLevel: true,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-          {
-            reviewerId: 5,
-            orgId: null,
-            stageId: 5,
-            stageNumber: 1,
-            status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4001,
-            allowedSections: null,
-            levelNumber: 1,
-            isLastLevel: true,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-          {
-            reviewerId: 7,
-            orgId: null,
-            stageId: 5,
-            stageNumber: 1,
-            status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4001,
-            allowedSections: null,
-            levelNumber: 1,
-            isLastLevel: true,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-          {
-            reviewerId: 8,
-            orgId: null,
-            stageId: 5,
-            stageNumber: 1,
-            status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4001,
-            allowedSections: null,
-            levelNumber: 1,
-            isLastLevel: true,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-          {
-            reviewerId: 9,
-            orgId: null,
-            stageId: 5,
-            stageNumber: 1,
-            status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4001,
-            allowedSections: null,
-            levelNumber: 1,
-            isLastLevel: true,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-        ],
-        reviewAssignmentIds: [1, 2, 3, 4, 1005, 6, 7],
-        reviewAssignmentAssignerJoins: [],
-        reviewAssignmentAssignerJoinIds: [],
-        nextStageNumber: 1,
-        nextReviewLevel: 1,
-      },
+      output: {},
     })
   })
 })
 
-test('Test: Submit Application ID#4002 - Stage 2 Lvl1', () => {
-  return generateReviewAssignments({
-    parameters: { templateId: 4, applicationId: 4002 }, // stageNumber: 2, stageId: 6, levels: 2
-    DBConnect,
-  }).then((result: any) => {
-    expect(clearResult(result)).toEqual({
-      status: ActionQueueStatus.Success,
-      error_log: '',
-      output: {
-        reviewAssignments: [
-          {
-            reviewerId: 7,
-            orgId: null,
-            stageId: 6,
-            stageNumber: 2,
-            status: ReviewAssignmentStatus.Available,
-            applicationId: 4002,
-            allowedSections: ['S1'],
-            levelNumber: 1,
-            isLastLevel: false,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-          {
-            reviewerId: 8,
-            orgId: null,
-            stageId: 6,
-            stageNumber: 2,
-            status: ReviewAssignmentStatus.Available,
-            applicationId: 4002,
-            allowedSections: ['S2'],
-            levelNumber: 1,
-            isLastLevel: false,
-            isLastStage: false,
-            isFinalDecision: false,
-          },
-        ],
-        reviewAssignmentIds: [1007, 1008],
-        reviewAssignmentAssignerJoins: [
-          {
-            assignerId: 11,
-            orgId: null,
-            reviewAssignmentId: 1007,
-          },
-          {
-            assignerId: 12,
-            orgId: null,
-            reviewAssignmentId: 1007,
-          },
-          {
-            assignerId: 11,
-            orgId: null,
-            reviewAssignmentId: 1008,
-          },
-          {
-            assignerId: 12,
-            orgId: null,
-            reviewAssignmentId: 1008,
-          },
-        ],
-        reviewAssignmentAssignerJoinIds: [1, 2, 3, 4],
-        nextStageNumber: 2,
-        nextReviewLevel: 1,
-      },
+// Simulate application submissions:
+describe('Submit new application on first stage to generate reviewAssignments on Stage 1', () => {
+  // Setup database
+  beforeAll(async (done) => {
+    await DBConnect.query({
+      text: `
+      INSERT INTO public.application (id, serial, template_id, name, outcome, user_id, org_id)
+        VALUES (1000, 'DFG123', 5, 'Test', 'PENDING', 5, 1);
+      INSERT INTO public.application_stage_history (id, application_id, stage_id, is_current)
+        VALUES (1000, 1000, 5, 'True');
+      INSERT INTO public.application_status_history (id, application_stage_history_id, status, is_current)
+        VALUES (DEFAULT, 1000, 'SUBMITTED', 'True');
+      `,
+      values: [],
+    })
+    done()
+  })
+
+  test('Test: Submit Application ID#1000 - Stage 1 Lvl 1 (last level)', () => {
+    //stageNumber: 1, stageId: 5, levels: 1
+    return generateReviewAssignments({
+      parameters: { applicationId: 1000 },
+      DBConnect,
+    }).then((result: any) => {
+      expect(result).toEqual({
+        status: ActionQueueStatus.Success,
+        error_log: '',
+        output: {
+          reviewAssignments: [
+            {
+              reviewerId: 2,
+              orgId: null,
+              stageId: 5,
+              stageNumber: 1,
+              status: ReviewAssignmentStatus.AvailableForSelfAssignment,
+              applicationId: 1000,
+              allowedSections: null,
+              levelNumber: 1,
+              isLastLevel: true,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+            {
+              reviewerId: 3,
+              orgId: null,
+              stageId: 5,
+              stageNumber: 1,
+              status: ReviewAssignmentStatus.AvailableForSelfAssignment,
+              applicationId: 1000,
+              allowedSections: null,
+              levelNumber: 1,
+              isLastLevel: true,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+            {
+              reviewerId: 4,
+              orgId: null,
+              stageId: 5,
+              stageNumber: 1,
+              status: ReviewAssignmentStatus.AvailableForSelfAssignment,
+              applicationId: 1000,
+              allowedSections: null,
+              levelNumber: 1,
+              isLastLevel: true,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+            {
+              reviewerId: 5,
+              orgId: null,
+              stageId: 5,
+              stageNumber: 1,
+              status: ReviewAssignmentStatus.AvailableForSelfAssignment,
+              applicationId: 1000,
+              allowedSections: null,
+              levelNumber: 1,
+              isLastLevel: true,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+            {
+              reviewerId: 7,
+              orgId: null,
+              stageId: 5,
+              stageNumber: 1,
+              status: ReviewAssignmentStatus.AvailableForSelfAssignment,
+              applicationId: 1000,
+              allowedSections: null,
+              levelNumber: 1,
+              isLastLevel: true,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+            {
+              reviewerId: 8,
+              orgId: null,
+              stageId: 5,
+              stageNumber: 1,
+              status: ReviewAssignmentStatus.AvailableForSelfAssignment,
+              applicationId: 1000,
+              allowedSections: null,
+              levelNumber: 1,
+              isLastLevel: true,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+            {
+              reviewerId: 9,
+              orgId: null,
+              stageId: 5,
+              stageNumber: 1,
+              status: ReviewAssignmentStatus.AvailableForSelfAssignment,
+              applicationId: 1000,
+              allowedSections: null,
+              levelNumber: 1,
+              isLastLevel: true,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+          ],
+          reviewAssignmentIds: [1, 2, 3, 4, 5, 6, 7],
+          reviewAssignmentAssignerJoins: [],
+          reviewAssignmentAssignerJoinIds: [],
+          nextStageNumber: 1,
+          nextReviewLevel: 1,
+        },
+      })
     })
   })
 })
 
-// Recreated test case for First Review submissiion (Stage 1 - generate assignment for Stage 2)
+describe('Re-submit new application on second stage to generate new reviewAssignments on Stage 2', () => {
+  // Setup database
+  beforeAll(async (done) => {
+    await DBConnect.query({
+      text: `
+      INSERT INTO public.application_stage_history (id, application_id, stage_id, is_current)
+        VALUES (1001, 1000, 6, 'True');
+      INSERT INTO public.application_status_history (id, application_stage_history_id, status, is_current)
+        VALUES (DEFAULT, 1001, 'SUBMITTED', 'True');
+      `,
+      values: [],
+    })
+    done()
+  })
+
+  test('Test: Submit Application ID#1000 - Stage 2 Lvl1', () => {
+    return generateReviewAssignments({
+      parameters: { applicationId: 1000 }, // stageNumber: 2, stageId: 6, levels: 2
+      DBConnect,
+    }).then((result: any) => {
+      expect(clearResult(result)).toEqual({
+        status: ActionQueueStatus.Success,
+        error_log: '',
+        output: {
+          reviewAssignments: [
+            {
+              reviewerId: 7,
+              orgId: null,
+              stageId: 6,
+              stageNumber: 2,
+              status: ReviewAssignmentStatus.Available,
+              applicationId: 1000,
+              allowedSections: ['S1'],
+              levelNumber: 1,
+              isLastLevel: false,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+            {
+              reviewerId: 8,
+              orgId: null,
+              stageId: 6,
+              stageNumber: 2,
+              status: ReviewAssignmentStatus.Available,
+              applicationId: 1000,
+              allowedSections: ['S2'],
+              levelNumber: 1,
+              isLastLevel: false,
+              isLastStage: false,
+              isFinalDecision: false,
+            },
+          ],
+          reviewAssignmentIds: [8, 9],
+          reviewAssignmentAssignerJoins: [
+            {
+              assignerId: 11,
+              orgId: null,
+              reviewAssignmentId: 8,
+            },
+            {
+              assignerId: 12,
+              orgId: null,
+              reviewAssignmentId: 8,
+            },
+            {
+              assignerId: 11,
+              orgId: null,
+              reviewAssignmentId: 9,
+            },
+            {
+              assignerId: 12,
+              orgId: null,
+              reviewAssignmentId: 9,
+            },
+          ],
+          reviewAssignmentAssignerJoinIds: [1, 2, 3, 4],
+          nextStageNumber: 2,
+          nextReviewLevel: 1,
+        },
+      })
+    })
+  })
+})
+
+// Recreated test case for First Review submission (Stage 1 - generate assignment for Stage 2)
 
 // Simulate review submission:
 
-test('Test: Submit Review ID#6003 for Application ID#4002 - Stage 2 Lvl 1 to update existing level 2 assignment', () => {
+test('Test: Submit Review ID#7002 for Application ID#4003 - Stage 2 Lvl 1 to generate level 2 assignments', () => {
   return generateReviewAssignments({
-    parameters: { templateId: 4, applicationId: 4002, reviewId: 6003 }, // stageNumber: 2, stageId: 6, levels: 2
+    parameters: { applicationId: 4003, reviewId: 7002 }, // stageNumber: 2, stageId: 6, levels: 2
     DBConnect,
   }).then((result: any) => {
     expect(clearResult(result)).toEqual({
@@ -223,7 +273,7 @@ test('Test: Submit Review ID#6003 for Application ID#4002 - Stage 2 Lvl 1 to upd
             stageNumber: 2,
             levelNumber: 2,
             status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4002,
+            applicationId: 4003,
             allowedSections: null,
             isLastLevel: true,
             isLastStage: false,
@@ -236,14 +286,14 @@ test('Test: Submit Review ID#6003 for Application ID#4002 - Stage 2 Lvl 1 to upd
             stageNumber: 2,
             levelNumber: 2,
             status: ReviewAssignmentStatus.AvailableForSelfAssignment,
-            applicationId: 4002,
+            applicationId: 4003,
             allowedSections: null,
             isLastLevel: true,
             isLastStage: false,
             isFinalDecision: false,
           },
         ],
-        reviewAssignmentIds: [1009, 1010],
+        reviewAssignmentIds: [10, 11],
         reviewAssignmentAssignerJoinIds: [],
         reviewAssignmentAssignerJoins: [],
         nextStageNumber: 2,
@@ -253,19 +303,21 @@ test('Test: Submit Review ID#6003 for Application ID#4002 - Stage 2 Lvl 1 to upd
   })
 })
 
-describe('Move Review to next stage (Final Decision) before generation of reviewAssignments', () => {
+describe('Create new Review to simulate application moving to last stage (Final Decision) to check generation reviewAssignments', () => {
   // Setup database
   beforeAll(async (done) => {
     await DBConnect.query({
       text: `
+      INSERT INTO public.review (id, application_id, review_assignment_id)
+        VALUES (8000, 4004, 10)
       INSERT INTO public.review_decision (id, decision, review_id)
-        VALUES (DEFAULT, 'NON_CONFORM', 7004);
+        VALUES (DEFAULT, 'NON_CONFORM', 8000);
       INSERT INTO public.review_status_history (id, review_id, status)
-        VALUES (DEFAULT, 7004, 'SUBMITTED'); 
+        VALUES (DEFAULT, 7004, 'SUBMITTED');
       INSERT INTO public.application_stage_history (id, application_id, stage_id, is_current)
-        VALUES (1000, 4004, 7, 'True');
+        VALUES (2000, 4004, 7, 'True');
       INSERT INTO public.application_status_history (id, application_stage_history_id, status, is_current)
-        VALUES (DEFAULT, 1000, 'SUBMITTED', 'True'); 
+        VALUES (DEFAULT, 2000, 'SUBMITTED', 'True');
       `,
       values: [],
     })

--- a/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
+++ b/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
@@ -124,8 +124,6 @@ async function generateReviewAssignments({
       nextLevelReviewers,
     })
 
-    console.log('ReviewAssignments', reviewAssignments)
-
     return generateNextReviewAssignments({
       db,
       templateId,

--- a/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
+++ b/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
@@ -190,15 +190,6 @@ const getReviewAssignmentsToGenerate = async ({
 
     if (existingReviewAssignment) return // Don't create new reviewAssignment if already exists
 
-    const existingReviewAssignment = db.checkExistingReviewAssignment({
-      applicationId,
-      stageNumber,
-      levelNumber: nextReviewLevel,
-      reviewerId: userId,
-    })
-
-    if (existingReviewAssignment) return // Don't create new reviewAssignment if already exists
-
     const userOrgKey = `${userId}_${orgId ? orgId : 0}`
     if (reviewAssignments[userOrgKey])
       reviewAssignments[userOrgKey].allowedSections =

--- a/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
+++ b/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
@@ -158,6 +158,15 @@ const generateNextReviewAssignments = async ({
       return ReviewAssignmentStatus.Available
     }
 
+    const existingReviewAssignment = db.checkExistingReviewAssignment({
+      applicationId,
+      stageNumber,
+      levelNumber: nextReviewLevel,
+      reviewerId: userId,
+    })
+
+    if (existingReviewAssignment) return // Don't create new reviewAssignment if already exists
+
     const userOrgKey = `${userId}_${orgId ? orgId : 0}`
     if (reviewAssignments[userOrgKey])
       reviewAssignments[userOrgKey].allowedSections =


### PR DESCRIPTION
Fixes  front-end https://github.com/openmsupply/application-manager-web-app/issues/690

Finally! It took me so long to fix the tests... `generateReviewAssignments` but now all the **existing** reviewAssignments aren't returned anymore, which is what was causing the problem.

### Changes
- Update Application 4 (serial: 45678) to not be already in Stage 2 Lvl 2 - so this case can be tested in `generateReviewAssignments` to generate reviewAssignments for next level in same stage
- Fix tests in `generateReviewAssignments` and `updateReviewStatuses` to be aligned with current application/assignments
- Add test specific to show no new reviewAssignments are created if there are already some for the same: `reviewer`, `stage`, `level` and `application`.

### Testing
- Use application ABC456 logged in with user **Reviewer1**
- Start review and DECLINE one response and submit the LOQ to applicant
- Log in with user **Valerio** and fix the response then re-submit
- Log in again as **Reviewer1** to Re-review and APPROVE all then CONFORM and submit
- Now the application is on the next stage. No other reviewAssignments have been created for other reviewer in stage 1

Check in the master to see the bug happening - you can check the logs to see new reviewAssignments created after re-submitting the application with LOQ back to the reviewer. 