### PR TITLE
#491 Category-specific layout settings

### DIFF
--- a/database/buildSchema/07A_template_category.sql
+++ b/database/buildSchema/07A_template_category.sql
@@ -1,8 +1,17 @@
 -- template category table
+--
+-- places in ui where template_categories can show up
+CREATE TYPE public.ui_location AS ENUM (
+    'DASHBOARD',
+    'MENU',
+    'USER'
+);
+
 CREATE TABLE public.template_category (
     id serial PRIMARY KEY,
     code varchar NOT NULL UNIQUE,
     title varchar,
-    icon varchar
+    icon varchar,
+    ui_location public.ui_location[] DEFAULT '{DASHBOARD, MENU}'
 );
 

--- a/database/buildSchema/07B_template.sql
+++ b/database/buildSchema/07B_template.sql
@@ -14,6 +14,7 @@ CREATE TABLE public.template (
     start_message jsonb,
     status public.template_status,
     submission_message jsonb DEFAULT '"Thank you! Your application has been submitted."' ::jsonb,
+    icon varchar,
     template_category_id integer REFERENCES public.template_category (id),
     version_timestamp timestamptz DEFAULT CURRENT_TIMESTAMP,
     version integer DEFAULT 1

--- a/database/insertData/_common/02D_template_categories.js
+++ b/database/insertData/_common/02D_template_categories.js
@@ -50,13 +50,14 @@ exports.queries = [
         code: "user"
         icon: "user"
         title: "User settings"
+        uiLocation: [ USER ]
       }
     }
   ) {
     clientMutationId
   }
 }`,
-`mutation licenseCategory {
+  `mutation licenseCategory {
   createTemplateCategory(
     input: {
       templateCategory: {

--- a/database/insertData/_common/03_template_G_userEdit.js
+++ b/database/insertData/_common/03_template_G_userEdit.js
@@ -13,6 +13,7 @@ exports.queries = [
           namePlural: "Edit Users Details" 
           submissionMessage: "Thanks for updating your details. You will need to log out and log back into the system for the changes to take effect."
           status: AVAILABLE
+          icon: "edit" # For User dropdown menu
           versionTimestamp: "NOW()"
           templateSectionsUsingId: {
             create: [

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -20338,7 +20338,7 @@ export type TemplateCategory = Node & {
   code: Scalars['String'];
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
-  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
+  uiLocation: Array<Maybe<UiLocation>>;
   /** Reads and enables pagination through a set of `Template`. */
   templates: TemplatesConnection;
 };
@@ -35316,7 +35316,7 @@ export type TemplateCategoryResolvers<ContextType = any, ParentType extends Reso
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   icon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  uiLocation?: Resolver<Maybe<Array<Maybe<ResolversTypes['UiLocation']>>>, ParentType, ContextType>;
+  uiLocation?: Resolver<Array<Maybe<ResolversTypes['UiLocation']>>, ParentType, ContextType>;
   templates?: Resolver<ResolversTypes['TemplatesConnection'], ParentType, ContextType, RequireFields<TemplateCategoryTemplatesArgs, 'orderBy'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -520,6 +520,7 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -3543,6 +3544,7 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -8464,6 +8466,7 @@ export type FileTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -17141,6 +17144,7 @@ export type ReviewAssignmentTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -19897,6 +19901,7 @@ export type Template = Node & {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -20270,6 +20275,7 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -20495,6 +20501,8 @@ export type TemplateCondition = {
   status?: Maybe<TemplateStatus>;
   /** Checks for equality with the object’s `submissionMessage` field. */
   submissionMessage?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `icon` field. */
+  icon?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `templateCategoryId` field. */
   templateCategoryId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `versionTimestamp` field. */
@@ -21084,6 +21092,8 @@ export type TemplateFilter = {
   status?: Maybe<TemplateStatusFilter>;
   /** Filter by the object’s `submissionMessage` field. */
   submissionMessage?: Maybe<JsonFilter>;
+  /** Filter by the object’s `icon` field. */
+  icon?: Maybe<StringFilter>;
   /** Filter by the object’s `templateCategoryId` field. */
   templateCategoryId?: Maybe<IntFilter>;
   /** Filter by the object’s `versionTimestamp` field. */
@@ -21403,6 +21413,7 @@ export type TemplateFilterJoinTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -21436,6 +21447,7 @@ export type TemplateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -21623,6 +21635,7 @@ export type TemplatePatch = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -21953,6 +21966,7 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -22293,6 +22307,7 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -22389,6 +22404,8 @@ export enum TemplatesOrderBy {
   StatusDesc = 'STATUS_DESC',
   SubmissionMessageAsc = 'SUBMISSION_MESSAGE_ASC',
   SubmissionMessageDesc = 'SUBMISSION_MESSAGE_DESC',
+  IconAsc = 'ICON_ASC',
+  IconDesc = 'ICON_DESC',
   TemplateCategoryIdAsc = 'TEMPLATE_CATEGORY_ID_ASC',
   TemplateCategoryIdDesc = 'TEMPLATE_CATEGORY_ID_DESC',
   VersionTimestampAsc = 'VERSION_TIMESTAMP_ASC',
@@ -22958,6 +22975,7 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -23122,6 +23140,7 @@ export type TemplateTemplateCategoryIdFkeyTemplateCreateInput = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
@@ -26900,6 +26919,7 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -26925,6 +26945,7 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -26950,6 +26971,7 @@ export type UpdateTemplateOnFileForFileTemplateIdFkeyPatch = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -26975,6 +26997,7 @@ export type UpdateTemplateOnReviewAssignmentForReviewAssignmentTemplateIdFkeyPat
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -27000,6 +27023,7 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -27025,6 +27049,7 @@ export type UpdateTemplateOnTemplateFilterJoinForTemplateFilterJoinTemplateIdFke
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -27050,6 +27075,7 @@ export type UpdateTemplateOnTemplateForTemplateTemplateCategoryIdFkeyPatch = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
@@ -27074,6 +27100,7 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -27099,6 +27126,7 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -27124,6 +27152,7 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
+  icon?: Maybe<Scalars['String']>;
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
@@ -35221,6 +35250,7 @@ export type TemplateResolvers<ContextType = any, ParentType extends ResolversPar
   startMessage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['TemplateStatus']>, ParentType, ContextType>;
   submissionMessage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  icon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   templateCategoryId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   versionTimestamp?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
   version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -20318,6 +20318,8 @@ export enum TemplateCategoriesOrderBy {
   TitleDesc = 'TITLE_DESC',
   IconAsc = 'ICON_ASC',
   IconDesc = 'ICON_DESC',
+  UiLocationAsc = 'UI_LOCATION_ASC',
+  UiLocationDesc = 'UI_LOCATION_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -20330,6 +20332,7 @@ export type TemplateCategory = Node & {
   code: Scalars['String'];
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
+  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
   /** Reads and enables pagination through a set of `Template`. */
   templates: TemplatesConnection;
 };
@@ -20359,6 +20362,8 @@ export type TemplateCategoryCondition = {
   title?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `icon` field. */
   icon?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `uiLocation` field. */
+  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
 };
 
 /** A filter to be used against `TemplateCategory` object types. All fields are combined with a logical ‘and.’ */
@@ -20371,6 +20376,8 @@ export type TemplateCategoryFilter = {
   title?: Maybe<StringFilter>;
   /** Filter by the object’s `icon` field. */
   icon?: Maybe<StringFilter>;
+  /** Filter by the object’s `uiLocation` field. */
+  uiLocation?: Maybe<UiLocationListFilter>;
   /** Filter by the object’s `templates` relation. */
   templates?: Maybe<TemplateCategoryToManyTemplateFilter>;
   /** Some related `templates` exist. */
@@ -20389,6 +20396,7 @@ export type TemplateCategoryInput = {
   code: Scalars['String'];
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
+  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
   templatesUsingId?: Maybe<TemplateTemplateCategoryIdFkeyInverseInput>;
 };
 
@@ -20432,6 +20440,7 @@ export type TemplateCategoryPatch = {
   code?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
+  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
   templatesUsingId?: Maybe<TemplateTemplateCategoryIdFkeyInverseInput>;
 };
 
@@ -23099,6 +23108,7 @@ export type TemplateTemplateCategoryIdFkeyTemplateCategoryCreateInput = {
   code: Scalars['String'];
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
+  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
   templatesUsingId?: Maybe<TemplateTemplateCategoryIdFkeyInverseInput>;
 };
 
@@ -23491,6 +23501,52 @@ export type TriggerQueueTriggerQueuePkeyConnect = {
 /** The fields on `triggerQueue` to look up the row to delete. */
 export type TriggerQueueTriggerQueuePkeyDelete = {
   id: Scalars['Int'];
+};
+
+export enum UiLocation {
+  Dashboard = 'DASHBOARD',
+  Menu = 'MENU',
+  User = 'USER'
+}
+
+/** A filter to be used against UiLocation List fields. All fields are combined with a logical ‘and.’ */
+export type UiLocationListFilter = {
+  /** Is null (if `true` is specified) or is not null (if `false` is specified). */
+  isNull?: Maybe<Scalars['Boolean']>;
+  /** Equal to the specified value. */
+  equalTo?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Not equal to the specified value. */
+  notEqualTo?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Not equal to the specified value, treating null like an ordinary value. */
+  distinctFrom?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Equal to the specified value, treating null like an ordinary value. */
+  notDistinctFrom?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Less than the specified value. */
+  lessThan?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Less than or equal to the specified value. */
+  lessThanOrEqualTo?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Greater than the specified value. */
+  greaterThan?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Greater than or equal to the specified value. */
+  greaterThanOrEqualTo?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Contains the specified list of values. */
+  contains?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Contained by the specified list of values. */
+  containedBy?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Overlaps the specified list of values. */
+  overlaps?: Maybe<Array<Maybe<UiLocation>>>;
+  /** Any array item is equal to the specified value. */
+  anyEqualTo?: Maybe<UiLocation>;
+  /** Any array item is not equal to the specified value. */
+  anyNotEqualTo?: Maybe<UiLocation>;
+  /** Any array item is less than the specified value. */
+  anyLessThan?: Maybe<UiLocation>;
+  /** Any array item is less than or equal to the specified value. */
+  anyLessThanOrEqualTo?: Maybe<UiLocation>;
+  /** Any array item is greater than the specified value. */
+  anyGreaterThan?: Maybe<UiLocation>;
+  /** Any array item is greater than or equal to the specified value. */
+  anyGreaterThanOrEqualTo?: Maybe<UiLocation>;
 };
 
 /** All input for the `updateActionPluginByCode` mutation. */
@@ -26567,6 +26623,7 @@ export type UpdateTemplateCategoryOnTemplateForTemplateTemplateCategoryIdFkeyPat
   code?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
+  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
   templatesUsingId?: Maybe<TemplateTemplateCategoryIdFkeyInverseInput>;
 };
 
@@ -29571,6 +29628,8 @@ export type ResolversTypes = {
   TemplateToManyReviewAssignmentFilter: TemplateToManyReviewAssignmentFilter;
   TemplateToManyFileFilter: TemplateToManyFileFilter;
   TemplateCategoryFilter: TemplateCategoryFilter;
+  UiLocationListFilter: UiLocationListFilter;
+  UiLocation: UiLocation;
   TemplateCategoryToManyTemplateFilter: TemplateCategoryToManyTemplateFilter;
   ActionQueuesConnection: ResolverTypeWrapper<ActionQueuesConnection>;
   ActionQueue: ResolverTypeWrapper<ActionQueue>;
@@ -31241,6 +31300,7 @@ export type ResolversParentTypes = {
   TemplateToManyReviewAssignmentFilter: TemplateToManyReviewAssignmentFilter;
   TemplateToManyFileFilter: TemplateToManyFileFilter;
   TemplateCategoryFilter: TemplateCategoryFilter;
+  UiLocationListFilter: UiLocationListFilter;
   TemplateCategoryToManyTemplateFilter: TemplateCategoryToManyTemplateFilter;
   ActionQueuesConnection: ActionQueuesConnection;
   ActionQueue: ActionQueue;
@@ -35226,6 +35286,7 @@ export type TemplateCategoryResolvers<ContextType = any, ParentType extends Reso
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   icon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  uiLocation?: Resolver<Maybe<Array<Maybe<ResolversTypes['UiLocation']>>>, ParentType, ContextType>;
   templates?: Resolver<ResolversTypes['TemplatesConnection'], ParentType, ContextType, RequireFields<TemplateCategoryTemplatesArgs, 'orderBy'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -20338,7 +20338,7 @@ export type TemplateCategory = Node & {
   code: Scalars['String'];
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
-  uiLocation: Array<Maybe<UiLocation>>;
+  uiLocation?: Maybe<Array<Maybe<UiLocation>>>;
   /** Reads and enables pagination through a set of `Template`. */
   templates: TemplatesConnection;
 };
@@ -35316,7 +35316,7 @@ export type TemplateCategoryResolvers<ContextType = any, ParentType extends Reso
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   icon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  uiLocation?: Resolver<Array<Maybe<ResolversTypes['UiLocation']>>, ParentType, ContextType>;
+  uiLocation?: Resolver<Maybe<Array<Maybe<ResolversTypes['UiLocation']>>>, ParentType, ContextType>;
   templates?: Resolver<ResolversTypes['TemplatesConnection'], ParentType, ContextType, RequireFields<TemplateCategoryTemplatesArgs, 'orderBy'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };


### PR DESCRIPTION
Fixes #491 as per agreed solution.

Test with [front-end PR #890](https://github.com/openmsupply/application-manager-web-app/pull/890)

Only extra thing I did was to add an 'icon' field to "template", so each template _can_ have its own icon. Only used in "User" menu for "Edit User details" currently. (If a template icon is called and its not defined, it'll fall back to the category icon)