### PR TITLE
#503 make sure enums inside array are not quoted

### DIFF
--- a/database/buildSchema/41_database_info.sql
+++ b/database/buildSchema/41_database_info.sql
@@ -20,12 +20,15 @@ SELECT
     columns_info.is_nullable,
     columns_info.is_generated,
     columns_info.data_type,
+    element_types.data_type AS sub_data_type,
     constraints_info.constraint_type,
     constraints_info.to_table_name AS fk_to_table_name,
     constraints_info.to_column_name AS fk_to_column_name
 FROM
     information_schema.tables AS tables_info
     JOIN information_schema.columns AS columns_info ON tables_info.table_name = columns_info.table_name
+    LEFT JOIN information_schema.element_types AS element_types ON columns_info.dtd_identifier = element_types.collection_type_identifier
+        AND columns_info.table_name = element_types.object_name
     LEFT JOIN constraints_info ON columns_info.table_name = constraints_info.from_table_name
         AND columns_info.column_name = constraints_info.from_column_name
 WHERE

--- a/src/components/exportAndImport/getDatabaseInfo.ts
+++ b/src/components/exportAndImport/getDatabaseInfo.ts
@@ -17,6 +17,7 @@ const getDatabaseInfo = async () => {
       column_name,
       is_generated,
       data_type,
+      sub_data_type,
       constraint_type,
       fk_to_table_name,
       fk_to_column_name,
@@ -40,6 +41,7 @@ const getDatabaseInfo = async () => {
       const isGenerated = is_generated === 'ALWAYS'
       const isEnum = data_type === 'USER-DEFINED'
       const isJson = data_type === 'jsonb'
+      const isEnumArray = data_type === 'ARRAY' && sub_data_type === 'USER-DEFINED'
 
       const fkTableName = camelCase(fk_to_table_name || '')
       const fkColumnName = camelCase(fk_to_column_name || '')
@@ -51,6 +53,7 @@ const getDatabaseInfo = async () => {
         isReference,
         isEnum,
         isJson,
+        isEnumArray,
         reference: !isReference
           ? { columnName: '', tableName: '' }
           : {

--- a/src/components/exportAndImport/importFromJson.ts
+++ b/src/components/exportAndImport/importFromJson.ts
@@ -153,6 +153,8 @@ const getInsertKeyValues = (values: ObjectRecord, columns: DatabaseColumn[]) => 
       if (column) {
         // Make sure enum values are not quoted
         if (column.isEnum) gqlValue = value
+        // Make sure enum values are not quoted in an array
+        if (column.isEnumArray) gqlValue = gqlValue.replace(/"/g, '')
         // Add quotes around object
         if (column.isJson && value instanceof Object) {
           const variableName = `$${columnName}`

--- a/src/components/exportAndImport/types.ts
+++ b/src/components/exportAndImport/types.ts
@@ -5,6 +5,7 @@ export type DatabaseColumn = {
   isGenerated: boolean
   isReference: boolean
   isEnum: boolean
+  isEnumArray: boolean
   isJson: boolean
   reference: {
     tableName: string

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -820,7 +820,7 @@ class PostgresDB {
         text: 'SELECT * FROM schema_columns where table_name like $1',
         values: [tableName],
       })
-      const responses = result.rows as schemaColumn[]
+      const responses = result.rows as SchemaColumn[]
       return responses
     } catch (err) {
       console.log(err.message)
@@ -849,18 +849,19 @@ export type permissionPolicyColumns = {
 
 type GetPermissionPolicies = () => Promise<permissionPolicyColumns[]>
 
-type schemaColumn = {
+type SchemaColumn = {
   table_name: string
   table_type: 'BASE TABLE' | 'VIEW'
   column_name: string
   is_nullable: 'YES' | 'NO'
   is_generated: 'ALWAYS' | 'NEVER'
-  data_type: 'USER-DEFINED' | 'jsonb' | string // only interested in USER-DEFINED (enum) and jsonb
+  data_type: 'USER-DEFINED' | 'jsonb' | 'ARRAY' | string // only interested in USER-DEFINED (enum), jsonb and array
+  sub_data_type: 'USER-DEFINED' | string // this is for arry type, only interested in USER-DEFINED (enum)
   constraint_type: 'PRIMARY KEY' | 'FOREIGN KEY' | 'UNIQUE' | null
   fk_to_table_name: string | null
   fk_to_column_name: string | null
 }
-type GetDatabaseInfo = (tableName?: string) => Promise<schemaColumn[]>
+type GetDatabaseInfo = (tableName?: string) => Promise<SchemaColumn[]>
 
 const postgressDBInstance = PostgresDB.Instance
 export default postgressDBInstance

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -19561,6 +19561,7 @@ export type SchemaColumn = {
   isNullable?: Maybe<Scalars['YesOrNo']>;
   isGenerated?: Maybe<Scalars['CharacterData']>;
   dataType?: Maybe<Scalars['CharacterData']>;
+  subDataType?: Maybe<Scalars['CharacterData']>;
   constraintType?: Maybe<Scalars['CharacterData']>;
   fkToTableName?: Maybe<Scalars['SqlIdentifier']>;
   fkToColumnName?: Maybe<Scalars['SqlIdentifier']>;
@@ -19583,6 +19584,8 @@ export type SchemaColumnCondition = {
   isGenerated?: Maybe<Scalars['CharacterData']>;
   /** Checks for equality with the object’s `dataType` field. */
   dataType?: Maybe<Scalars['CharacterData']>;
+  /** Checks for equality with the object’s `subDataType` field. */
+  subDataType?: Maybe<Scalars['CharacterData']>;
   /** Checks for equality with the object’s `constraintType` field. */
   constraintType?: Maybe<Scalars['CharacterData']>;
   /** Checks for equality with the object’s `fkToTableName` field. */
@@ -19605,6 +19608,8 @@ export type SchemaColumnFilter = {
   isGenerated?: Maybe<CharacterDataFilter>;
   /** Filter by the object’s `dataType` field. */
   dataType?: Maybe<CharacterDataFilter>;
+  /** Filter by the object’s `subDataType` field. */
+  subDataType?: Maybe<CharacterDataFilter>;
   /** Filter by the object’s `constraintType` field. */
   constraintType?: Maybe<CharacterDataFilter>;
   /** Filter by the object’s `fkToTableName` field. */
@@ -19656,6 +19661,8 @@ export enum SchemaColumnsOrderBy {
   IsGeneratedDesc = 'IS_GENERATED_DESC',
   DataTypeAsc = 'DATA_TYPE_ASC',
   DataTypeDesc = 'DATA_TYPE_DESC',
+  SubDataTypeAsc = 'SUB_DATA_TYPE_ASC',
+  SubDataTypeDesc = 'SUB_DATA_TYPE_DESC',
   ConstraintTypeAsc = 'CONSTRAINT_TYPE_ASC',
   ConstraintTypeDesc = 'CONSTRAINT_TYPE_DESC',
   FkToTableNameAsc = 'FK_TO_TABLE_NAME_ASC',
@@ -35216,6 +35223,7 @@ export type SchemaColumnResolvers<ContextType = any, ParentType extends Resolver
   isNullable?: Resolver<Maybe<ResolversTypes['YesOrNo']>, ParentType, ContextType>;
   isGenerated?: Resolver<Maybe<ResolversTypes['CharacterData']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['CharacterData']>, ParentType, ContextType>;
+  subDataType?: Resolver<Maybe<ResolversTypes['CharacterData']>, ParentType, ContextType>;
   constraintType?: Resolver<Maybe<ResolversTypes['CharacterData']>, ParentType, ContextType>;
   fkToTableName?: Resolver<Maybe<ResolversTypes['SqlIdentifier']>, ParentType, ContextType>;
   fkToColumnName?: Resolver<Maybe<ResolversTypes['SqlIdentifier']>, ParentType, ContextType>;


### PR DESCRIPTION
fixes: #503 
branched from 

enums to be not quoted inside array

### Changes

* Get type of array through information_schema.element_types 
* add isEnumArray to column type of database info
* remove quotes from stringified gqlValue is isEnumArray

### Testing

* Take snapshot `yarn ts-node ./database/snapshotCLI.ts take`
* Load snapshot `yarn ts-node ./database/snapshotCLI.ts use`
* Comment out `if (column.isEnumArray) gqlValue = gqlValue.replace(/"/g, '')` and load snapshot :/