### PR TITLE
Object properties fix

### DIFF
--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -280,7 +280,7 @@ const extractProperty = (
   const currentProperty = propertyPathArray[0]
   if (propertyPathArray.length === 1)
     return data?.[currentProperty] === undefined ? fallback : data[currentProperty]
-  else return extractProperty(data[currentProperty], propertyPathArray.slice(1), fallback)
+  else return extractProperty(data?.[currentProperty], propertyPathArray.slice(1), fallback)
 }
 
 // If Object has only 1 property, return just the value of that property,

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -600,7 +600,7 @@ testData.objectPropertyUnresolved = {
 
 testData.objectPropertyUnresolvedWithNullFallback = {
   operator: 'objectProperties',
-  children: ['application.querstions.q2', null],
+  children: ['application.querstions.q2.go.even.deeper', null],
 }
 
 testData.objectPropertyUnresolvedDeepWithNullFallback = {


### PR DESCRIPTION
Quick fix for this bug, where it would throw an error if the path was unresolved at a higher level that the last one.

Didn't end up replacing with lodash as this Object properties extractor does a couple of things differently, which I quite like.