### PR TITLE
#510 Additional UI Location -- Admin

### DIFF
--- a/database/buildSchema/07A_template_category.sql
+++ b/database/buildSchema/07A_template_category.sql
@@ -4,7 +4,8 @@
 CREATE TYPE public.ui_location AS ENUM (
     'DASHBOARD',
     'MENU',
-    'USER'
+    'USER',
+    'ADMIN'
 );
 
 CREATE TABLE public.template_category (

--- a/database/buildSchema/07A_template_category.sql
+++ b/database/buildSchema/07A_template_category.sql
@@ -3,7 +3,7 @@
 -- places in ui where template_categories can show up
 CREATE TYPE public.ui_location AS ENUM (
     'DASHBOARD',
-    'MENU',
+    'LIST',
     'USER',
     'ADMIN'
 );
@@ -13,6 +13,6 @@ CREATE TABLE public.template_category (
     code varchar NOT NULL UNIQUE,
     title varchar,
     icon varchar,
-    ui_location public.ui_location[] DEFAULT '{DASHBOARD, MENU}'
+    ui_location public.ui_location[] DEFAULT '{DASHBOARD, LIST}'
 );
 

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -24191,8 +24191,9 @@ export type TriggerScheduleTriggerSchedulePkeyDelete = {
 
 export enum UiLocation {
   Dashboard = 'DASHBOARD',
-  Menu = 'MENU',
-  User = 'USER'
+  List = 'LIST',
+  User = 'USER',
+  Admin = 'ADMIN'
 }
 
 /** A filter to be used against UiLocation List fields. All fields are combined with a logical ‘and.’ */


### PR DESCRIPTION
Fixes #510 

See front-end ???

Also renamed "MENU" to "LIST", since "MENU" is ambiguous.

So we now have 4 UI locations options:

1. DASHBOARD
2. LIST -- shows in "Application List" menu and links to list page filtered by type
3. USER -- shows in "User" menu (right-button), and links to new application page
4. ADMIN -- shows in "Admin Configurations" menu and links to new application page