### PR TITLE
Actions -- Better handling for condition check fail AND outputCumulative fix from scheduled trigger

### DIFF
--- a/src/components/actions/triggersAndActions.ts
+++ b/src/components/actions/triggersAndActions.ts
@@ -118,7 +118,7 @@ export async function processTrigger(payload: TriggerPayload) {
 
   // Collect output properties of actions in sequence
   // "data" is stored output from scheduled triggers or verifications
-  let outputCumulative = { ...data }
+  let outputCumulative = { ...data?.outputCumulative }
 
   // Execute sequential Actions one by one
   let actionFailed = ''

--- a/src/components/actions/triggersAndActions.ts
+++ b/src/components/actions/triggersAndActions.ts
@@ -196,10 +196,23 @@ export async function executeAction(
   }
 
   // Evaluate condition
-  const condition = await evaluateExpression(
-    payload.condition_expression as EvaluatorNode,
-    evaluatorParams
-  )
+  let condition
+  try {
+    condition = await evaluateExpression(
+      payload.condition_expression as EvaluatorNode,
+      evaluatorParams
+    )
+  } catch (err) {
+    console.log('>> Error evaluating condition for action:', payload.code)
+    return await DBConnect.executedActionStatusUpdate({
+      status: ActionQueueStatus.Fail,
+      error_log: 'Problem evaluating condition: ' + err,
+      parameters_evaluated: null,
+      output: null,
+      id: payload.id,
+    })
+  }
+
   if (condition) {
     try {
       // Evaluate parameters


### PR DESCRIPTION
No issue sorry, just a quick update I made to demo, so adding it here as well.

Basically, was having a problem with the "condition" expression failing, which was causing the action in the queue to stay in a perpetual "PROCESSING" state, which affected other actions for the same template causing them to fail too.

This fix just specifically handles the case when the condition check fails, and aborts that action (sets it to FAIL rather than PROCESSING) and adds some error info to the error_log

EDIT: Also pushed a quick fix where "outputCumulative" was being returned from scheduled trigger event nested 1 level too deep.