### PR TITLE
#529 grafana and docker compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,9 @@ RUN rm .npmrc && mv .npmrc_backup .npmrc
 COPY nginx_config/application_manager.conf /etc/nginx/conf.d/
 
 # --- ADD POSTGRES CONFIG
+WORKDIR /etc/postgresql/${POSTGRES_VERSION}/main6
 WORKDIR /etc/postgresql/${POSTGRES_VERSION}/main
+RUN echo "listen_addresses = '*'" >> postgresql.conf
 COPY postgres_config/pg_hba.conf .
 
 ARG INITIAL_DATA_LOCALE=dev
@@ -104,6 +106,7 @@ RUN ./database.sh ${INITIAL_DATA_LOCALE}
 WORKDIR /var/log/application_manager
 
 # --- PREPARING ENTRY
+WORKDIR /usr/src/entry6
 WORKDIR /usr/src/entry
 COPY entry.sh .
 WORKDIR /usr/src/application-manager-server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,8 +66,6 @@ RUN git clone -b ${WEB_APP_BRANCH} https://github.com/openmsupply/application-ma
 
 # --- BUILD SERVER
 WORKDIR /usr/src/application-manager-server
-RUN git fetch
-RUN git pull
 RUN cp .npmrc .npmrc_backup
 RUN echo "" >> .npmrc
 RUN --mount=type=secret,id=githubtoken,dst=/githubtoken echo "//npm.pkg.github.com/:_authToken=$(cat /githubtoken)" >> .npmrc
@@ -77,8 +75,6 @@ RUN rm .npmrc && mv .npmrc_backup .npmrc
 
 # --- BUILD WEB APP
 WORKDIR /usr/src/application-manager-web-app
-RUN git fetch
-RUN git pull
 RUN cp .npmrc .npmrc_backup
 RUN echo "" >> .npmrc
 RUN --mount=type=secret,id=githubtoken,dst=/githubtoken echo "//npm.pkg.github.com/:_authToken=$(cat /githubtoken)" >> .npmrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,6 @@ RUN rm .npmrc && mv .npmrc_backup .npmrc
 COPY nginx_config/application_manager.conf /etc/nginx/conf.d/
 
 # --- ADD POSTGRES CONFIG
-WORKDIR /etc/postgresql/${POSTGRES_VERSION}/main6
 WORKDIR /etc/postgresql/${POSTGRES_VERSION}/main
 RUN echo "listen_addresses = '*'" >> postgresql.conf
 COPY postgres_config/pg_hba.conf .
@@ -106,7 +105,6 @@ RUN ./database.sh ${INITIAL_DATA_LOCALE}
 WORKDIR /var/log/application_manager
 
 # --- PREPARING ENTRY
-WORKDIR /usr/src/entry6
 WORKDIR /usr/src/entry
 COPY entry.sh .
 WORKDIR /usr/src/application-manager-server

--- a/docker/database.sh
+++ b/docker/database.sh
@@ -20,3 +20,6 @@ echo '--- ADDING DATA'
 echo '--- RUNING POST INSTALL'
 ./database/turn_on_row_level_security.sh 
 ./database/post_data_insert.sh 
+
+echo '--- COPY CLEAN DATABASE TO BE USED IF NO VOLUMES ARE MOUNTED'
+cp -R /var/lib/postgresql/12/main/ ./fresh_db

--- a/docker/demo_server/.gitignore
+++ b/docker/demo_server/.gitignore
@@ -1,0 +1,2 @@
+/app_*
+/grafana_*

--- a/docker/demo_server/README.md
+++ b/docker/demo_server/README.md
@@ -39,11 +39,23 @@ docker-compose will complain if directories are not present, create them if need
 
 ```bash
 mkdir app_snapshots_on_port_8000
+mkdir app_postgres_on_port_8000
 mkdir grafana_on_port_8001
 
+mkdir app_snapshots_on_port_8002
+mkdir app_postgres_on_port_8002
 mkdir grafana_on_port_8003
+
+mkdir app_snapshots_on_port_8004
+mkdir app_postgres_on_port_8004
 mkdir grafana_on_port_8005
+
+mkdir app_snapshots_on_port_8006
+mkdir app_postgres_on_port_8006
 mkdir grafana_on_port_8007
+
+mkdir app_snapshots_on_port_8008
+mkdir app_postgres_on_port_8008
 mkdir grafana_on_port_8009
 ```
 
@@ -83,7 +95,7 @@ sudo docker exec -ti mflow-on-8000_app_1 cat /var/log/application_manager/graphi
 # to stop
 sudo docker-compose --project-name 'mflow-on-8000' stop
 # to remove (when new version is out)
-sudo docker-compose --project-name 'mflow-on-8000' rm
+sudo docker-compose --project-name 'mflow-on-8000' down
 ```
 
 Have t

--- a/docker/demo_server/README.md
+++ b/docker/demo_server/README.md
@@ -33,9 +33,9 @@ After changing config as per above, run
 
 Logs are in /var/log/nginx
 
-### Docker Compose
+### docker-compose
 
-Docker compose will complain if directories are not present, create them if needed (they will persist when restarting image, even if `docker compose down` was run)
+docker-compose will complain if directories are not present, create them if needed (they will persist when restarting image, even if `docker-compose down` was run)
 
 ```bash
 mkdir app_snapshots_on_port_8000
@@ -53,12 +53,12 @@ mkdir grafana_on_port_8009
 export TAG='front-demo-19-08-2021_back-demo-19-08-2021_pg-12_node-14'
 
 # -d is for detached, if you want to see all output then start without -d
-PORT_APP=8000 PORT_DASH=8001 sudo docker compose --project-name 'mflow-on-8000' up -d
+PORT_APP=8000 PORT_DASH=8001 sudo docker-compose --project-name 'mflow-on-8000' up -d
 
-PORT_APP=8002 PORT_DASH=8003 sudo docker compose --project-name 'mflow-on-8002' up -d
-PORT_APP=8004 PORT_DASH=8005 sudo docker compose --project-name 'mflow-on-8004' up -d
-PORT_APP=8006 PORT_DASH=8007 sudo docker compose --project-name 'mflow-on-8006' up -d
-PORT_APP=8008 PORT_DASH=8009 sudo docker compose --project-name 'mflow-on-8008' up -d
+PORT_APP=8002 PORT_DASH=8003 sudo docker-compose --project-name 'mflow-on-8002' up -d
+PORT_APP=8004 PORT_DASH=8005 sudo docker-compose --project-name 'mflow-on-8004' up -d
+PORT_APP=8006 PORT_DASH=8007 sudo docker-compose --project-name 'mflow-on-8006' up -d
+PORT_APP=8008 PORT_DASH=8009 sudo docker-compose --project-name 'mflow-on-8008' up -d
 ```
 
 <ins>list container</ins>
@@ -81,14 +81,14 @@ sudo docker exec -ti mflow-on-8000_app_1 cat /var/log/application_manager/graphi
 
 ```bash
 # to stop
-sudo docker compose --project-name 'mflow-on-8000' stop
+sudo docker-compose --project-name 'mflow-on-8000' stop
 # to remove (when new version is out)
-sudo docker compose --project-name 'mflow-on-8000' rm
+sudo docker-compose --project-name 'mflow-on-8000' rm
 ```
 
 Have t
 
-### Prior To Docker Compose
+### Prior To docker-compose
 
 <ins>list local images</ins>
 

--- a/docker/demo_server/README.md
+++ b/docker/demo_server/README.md
@@ -40,23 +40,35 @@ docker-compose will complain if directories are not present, create them if need
 ```bash
 mkdir app_snapshots_on_port_8000
 mkdir app_postgres_on_port_8000
+
 mkdir grafana_on_port_8001
+# grafana user has to own the local directory that's mounted to volume
+# https://community.grafana.com/t/new-docker-install-with-persistent-storage-permission-problem/10896/2
+sudo chown 472 grafana_on_port_8001
 
 mkdir app_snapshots_on_port_8002
 mkdir app_postgres_on_port_8002
+
 mkdir grafana_on_port_8003
+sudo chown 472 grafana_on_port_8003
 
 mkdir app_snapshots_on_port_8004
 mkdir app_postgres_on_port_8004
+
 mkdir grafana_on_port_8005
+sudo chown 472 grafana_on_port_8005
 
 mkdir app_snapshots_on_port_8006
 mkdir app_postgres_on_port_8006
+
 mkdir grafana_on_port_8007
+sudo chown 472 grafana_on_port_8007
 
 mkdir app_snapshots_on_port_8008
 mkdir app_postgres_on_port_8008
+
 mkdir grafana_on_port_8009
+sudo chown 472 grafana_on_port_8009
 ```
 
 <ins>launching all</ins>
@@ -65,12 +77,12 @@ mkdir grafana_on_port_8009
 export TAG='front-demo-19-08-2021_back-demo-19-08-2021_pg-12_node-14'
 
 # -d is for detached, if you want to see all output then start without -d
-PORT_APP=8000 PORT_DASH=8001 sudo docker-compose --project-name 'mflow-on-8000' up -d
+PORT_APP=8000 PORT_DASH=8001 sudo -E docker-compose --project-name 'mflow-on-8000' up -d
 
-PORT_APP=8002 PORT_DASH=8003 sudo docker-compose --project-name 'mflow-on-8002' up -d
-PORT_APP=8004 PORT_DASH=8005 sudo docker-compose --project-name 'mflow-on-8004' up -d
-PORT_APP=8006 PORT_DASH=8007 sudo docker-compose --project-name 'mflow-on-8006' up -d
-PORT_APP=8008 PORT_DASH=8009 sudo docker-compose --project-name 'mflow-on-8008' up -d
+PORT_APP=8002 PORT_DASH=8003 sudo -E docker-compose --project-name 'mflow-on-8002' up -d
+PORT_APP=8004 PORT_DASH=8005 sudo -E docker-compose --project-name 'mflow-on-8004' up -d
+PORT_APP=8006 PORT_DASH=8007 sudo -E docker-compose --project-name 'mflow-on-8006' up -d
+PORT_APP=8008 PORT_DASH=8009 sudo -E docker-compose --project-name 'mflow-on-8008' up -d
 ```
 
 <ins>list container</ins>

--- a/docker/demo_server/README.md
+++ b/docker/demo_server/README.md
@@ -1,0 +1,107 @@
+### SSH
+
+<ins>connect to instance</ins>
+
+```bash
+export KEY_LOC='~/Documents/private/irimskey.pem'
+
+ssh -i $KEY_LOC ubuntu@irims-demo.msupply.org
+```
+
+<ins>move files/folder to/from instance</ins>
+
+```bash
+export KEY_LOC='~/Documents/private/irimskey.pem'
+
+# demo server scripts
+scp -r -i $KEY_LOC ./demo_server ubuntu@irims-demo.msupply.org:/home/ubuntu/
+
+# nginx config for demo server to local
+scp -i $KEY_LOC ubuntu@irims-demo.msupply.org:/etc/nginx/sites-enabled/default ./demo_server/nginx_config
+
+# cannot directly replace default config, need to do it as sudo, so from within docker instance
+sudo mv demo_server/nginx_config/default /etc/nginx/sites-enabled/
+```
+
+### NGINX
+
+Everything should be configured via `default` config. Cert bot was installed and should auto update certs (https://certbot.eff.org/lets-encrypt/ubuntubionic-nginx).
+
+After changing config as per above, run
+
+`sudo service nginx restart`
+
+Logs are in /var/log/nginx
+
+### Docker Compose
+
+Docker compose will complain if directories are not present, create them if needed (they will persist when restarting image, even if `docker compose down` was run)
+
+```bash
+mkdir app_snapshots_on_port_8000
+mkdir grafana_on_port_8001
+
+mkdir grafana_on_port_8003
+mkdir grafana_on_port_8005
+mkdir grafana_on_port_8007
+mkdir grafana_on_port_8009
+```
+
+<ins>launching all</ins>
+
+```bash
+export TAG='front-demo-19-08-2021_back-demo-19-08-2021_pg-12_node-14'
+
+# -d is for detached, if you want to see all output then start without -d
+PORT_APP=8000 PORT_DASH=8001 sudo docker compose --project-name 'mflow-on-8000' up -d
+
+PORT_APP=8002 PORT_DASH=8003 sudo docker compose --project-name 'mflow-on-8002' up -d
+PORT_APP=8004 PORT_DASH=8005 sudo docker compose --project-name 'mflow-on-8004' up -d
+PORT_APP=8006 PORT_DASH=8007 sudo docker compose --project-name 'mflow-on-8006' up -d
+PORT_APP=8008 PORT_DASH=8009 sudo docker compose --project-name 'mflow-on-8008' up -d
+```
+
+<ins>list container</ins>
+
+`sudo docker container ls`
+
+<ins>bin bash inside container</ins>
+
+`sudo docker exec -ti mflow-on-8000_app_1 /bin/bash`
+
+<ins>view logs</ins>
+
+```bash
+# don't need bash inside contiainer for this
+sudo docker exec -ti mflow-on-8000_app_1 cat /var/log/application_manager/server.log
+sudo docker exec -ti mflow-on-8000_app_1 cat /var/log/application_manager/graphile.log
+```
+
+<ins>stop or remove</ins>
+
+```bash
+# to stop
+sudo docker compose --project-name 'mflow-on-8000' stop
+# to remove (when new version is out)
+sudo docker compose --project-name 'mflow-on-8000' rm
+```
+
+Have t
+
+### Prior To Docker Compose
+
+<ins>list local images</ins>
+
+`sudo docker images`
+
+<ins>remove all containers</ins>
+
+`sudo docker rm $(sudo docker ps -a -q)`
+
+<ins>remove all images</ins>
+
+`sudo docker rmi -f $(sudo docker images -a -q)`
+
+<ins>remove all images</ins>
+
+`sudo docker volume prune`

--- a/docker/demo_server/docker-compose.yml
+++ b/docker/demo_server/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3.9'
 services:
   app:
-    image: 'msupplyfoundation/mflow-demo:${TAG}'
+    image: 'mflow-demo:${TAG}'
     ports:
       - '${PORT_APP}:3000'
     expose:

--- a/docker/demo_server/docker-compose.yml
+++ b/docker/demo_server/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3.9'
 services:
   app:
-    image: 'mflow-demo:${TAG}'
+    image: 'msupplyfoundation/mflow-demo:${TAG}'
     ports:
       - '${PORT_APP}:3000'
     expose:

--- a/docker/demo_server/docker-compose.yml
+++ b/docker/demo_server/docker-compose.yml
@@ -1,0 +1,22 @@
+# mkdir grafana_on_port_(port)
+
+version: '3.9'
+services:
+  app:
+    image: 'mflow-demo:${TAG}'
+    ports:
+      - '${PORT_APP}:3000'
+    expose:
+      - '5432'
+    environment:
+      SMTP_PASSWORD: 'smt_password_goes_here'
+    volumes:
+      - ./app_postgres_on_port_${PORT_APP}:/var/lib/postgresql/12/main/
+      - ./app_snapshots_on_port_${PORT_APP}:/usr/src/application-manager-server/build/database/_snapshots
+    tty: true
+  grafana:
+    image: 'grafana/grafana'
+    ports:
+      - '${PORT_DASH}:3000'
+    volumes:
+      - ./grafana_on_port_${PORT_DASH}:/var/lib/grafana

--- a/docker/demo_server/nginx_config/default
+++ b/docker/demo_server/nginx_config/default
@@ -1,0 +1,153 @@
+# copy to /etc/nginx/sites-enabled/default, using "scp" (might need to copy to /home/ubuntu/default first then log in to server and copy with sudo)
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50000 ssl ipv6only=on; # managed by Certbot
+    listen 50000 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8000/;
+	}
+}
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50001 ssl ipv6only=on; # managed by Certbot
+    listen 50001 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8001/;
+	}
+}
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50002 ssl ipv6only=on; # managed by Certbot
+    listen 50002 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8002/;
+	}
+}
+
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50003 ssl ipv6only=on; # managed by Certbot
+    listen 50003 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8003/;
+	}
+}
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50004 ssl ipv6only=on; # managed by Certbot
+    listen 50004 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8004/;
+	}
+}
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50005 ssl ipv6only=on; # managed by Certbot
+    listen 50005 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8005/;
+	}
+}
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50006 ssl ipv6only=on; # managed by Certbot
+    listen 50000 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8006/;
+	}
+}
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50007 ssl ipv6only=on; # managed by Certbot
+    listen 50001 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8007/;
+	}
+}
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50008 ssl ipv6only=on; # managed by Certbot
+    listen 50002 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8008/;
+	}
+}
+
+
+server {
+    gzip_types text/plain application/xml text/css application/javascript; 
+
+    listen [::]:50009 ssl ipv6only=on; # managed by Certbot
+    listen 50003 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/irims-demo.msupply.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/irims-demo.msupply.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+	location / {
+     proxy_pass http://127.0.0.1:8009/;
+	}
+}

--- a/docker/dockerise.sh
+++ b/docker/dockerise.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# This command requires githubtoken.txt, in the repo root (it's git ingored btw). 
+# This command requires githubtoken.txt, in the repo root (it's git ingored btw).
 # githubtoken.txt should contain github token: https://github.com/settings/tokens -> generate new token -> [x] read:packages
 
-SERVER_BRANCH='b0-0-1' 
-WEB_APP_BRANCH='b0-0-1'  
-IMAGE_NAME='irims-demo'
-INITIAL_DATA_LOCALE='laos'
+SERVER_BRANCH='B-1.0.0'
+WEB_APP_BRANCH='B-1.0.0'
+IMAGE_NAME='mflow-demo'
+INITIAL_DATA_LOCALE=''
 
 NODE_VERSION='14'
 POSTGRES_VERSION='12'
@@ -18,7 +18,7 @@ echo "building image: ${IMAGE_TAG}"
 docker build \
    --progress plain \
    -t "${IMAGE_NAME}:${IMAGE_TAG}" \
-   --build-arg SERVER_BRANCH="$SERVER_BRANCH"\
+   --build-arg SERVER_BRANCH="$SERVER_BRANCH" \
    --build-arg WEB_APP_BRANCH="$WEB_APP_BRANCH" \
    --build-arg NODE_VERSION="$NODE_VERSION" \
    --build-arg POSTGRES_VERSION="$POSTGRES_VERSION" \

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+if [[ ! -f /var/lib/postgresql/12/main/PG_VERSION ]]
+then
+   echo '---'
+   echo 'copying fresh db to new mounted volume'
+   echo '---'
+   cp -r ./fresh_db/* /var/lib/postgresql/12/main
+   chown -R postgres:postgres /var/lib/postgresql/12/*
+   chmod -R 0700 /var/lib/postgresql/12/*
+fi
+
 echo '---'
 echo '---'
 echo '--- STARTING POSTGRES'

--- a/docker/postgres_config/pg_hba.conf
+++ b/docker/postgres_config/pg_hba.conf
@@ -1,3 +1,3 @@
 # allow all local connections (with no password)
 local   all             all                                     trust
-host    all             all             127.0.0.1/32            trust
+host    all             all             0.0.0.0/0               trust

--- a/docker/usefullScripts.txt
+++ b/docker/usefullScripts.txt
@@ -1,8 +1,0 @@
-# remove all containers
-docker rm $(docker ps -a -q)
-
-# remove all images
-docker rmi -f $(docker images -a -q)
-
-# remove all volumes
-docker volume prune


### PR DESCRIPTION
Fixes: #529 

For full details see screencast from telegram

### Changes

* New readme file for information about (wasn't sure if it needs to be in the docs)
* demo server folder that can be pushed to demo server (see readme files)
* allow for volumes to work in our current image (by creating a copy of fresh database initialisation and copying during image startup if one doesn't exist, i.e. if it using mounted empty volume)
* create docker compose that exposes grafana and mflow image together (linked their networks) and mounts volumes on local system
* demo server nginx config to live in demo server folder

I've updated demo server with 5002 - mFlow and 5003 - Grafana (reserving 5001 for Grafana of first instance)

Also made a of a 'release' (release candidate)
 