### PR TITLE
Handle missing aliases file

### DIFF
--- a/database/snapshotCLI.ts
+++ b/database/snapshotCLI.ts
@@ -41,8 +41,6 @@ const getSnapshotName = (lastParameterAlreadyRead: boolean) => {
   const name = process.argv[process.argv.length - 1]
   if (name in aliases) return aliases[name]
   else return name
-
-  return process.argv[process.argv.length - 1]
 }
 
 const doOperation = async () => {


### PR DESCRIPTION
Quick fix for when the `snapshot_path_aliases.json` file is missing from database folder. Instead of failing the int script, it'll just log a warning and carry on.