### PR TITLE
#541 Snapshots - file import fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dev_pg": "concurrently --kill-others-on-fail \"yarn dev\"  \"yarn pg\"",
     "dev_pg_permissions": "concurrently --kill-others-on-fail \"yarn dev\"  \"yarn pg_permissions\"",
     "database_init": "./database/initialise_database.sh tmf_app_manager && ./database/insert_data.sh",
-    "postdatabase_init": "./database/turn_on_row_level_security.sh && ./database/post_data_insert.sh && rm -rf ./files && mkdir ./files",
+    "postdatabase_init": "./database/turn_on_row_level_security.sh && ./database/post_data_insert.sh",
     "build_plugins": "node ./utils/pluginScripts/buildPlugins.js",
     "push_docs": "exec ./utils/push_docs_to_wiki.sh",
     "gui": "cd ./src/modules/expression-evaluator && yarn gui",

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -109,8 +109,12 @@ const copyFiles = (snapshotFolder: string) => {
   console.log('copying files ...')
   // -p = no error if exists
   execSync(`mkdir -p ${FILES_FOLDER}`)
-  execSync(`cp -R ${snapshotFolder}/files ${FILES_FOLDER}`)
-  console.log('copying files ... done')
+  try {
+    execSync(`cp -R ${snapshotFolder}/files/* ${FILES_FOLDER}`)
+    console.log('copying files ... done')
+  } catch {
+    console.log('No files to copy')
+  }
 }
 
 export default useSnapshot


### PR DESCRIPTION
Fixes #541

Two problems fixed:
- files were being imported a level too deep (i.e. `/files/files`), fixed so it now copies `/files/*` rather than `/files` from snapshot folder into (existing) files folder
- post insert script was clearing the files folder. Removed this (which means files folder will start to fill up so will need manual management)