### PR TITLE
Make snapshots folder if it's not there.

### DIFF
--- a/database/insert_data.sh
+++ b/database/insert_data.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #copy folder with snapshot_basic for inital Application manager setup
+mkdir ./database/_snapshots
 cp -rf ./database/basic_snapshot ./database/_snapshots
 
 #insert data from


### PR DESCRIPTION
Quick little fix.

insert_data script assumed `./datasbase/_snapshots` folder already existed, and was copying "basic_snapshot" incorrectly if it wasn't.

Added a `mkdir` to always try and create the "_snapshots" folder first.