### PR TITLE
Fix _snapshots folder missing from build

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,7 +5,7 @@
 docker run \
     -ti \
     -p 3000:3000 \
-    -e "SMTP_PASSWORD=smt_password_goes_here" \
+    -e 'SMTP_PASSWORD=smtp_password_goes_here' \
     testbuild
 
 # -ti -> interactive (connect to shell on startup)

--- a/utils/build_all.sh
+++ b/utils/build_all.sh
@@ -4,13 +4,15 @@ echo 'removing build folder'
 rm -rf ./build
 echo 'building app with tsc'
 tsc
-echo 'copying images' 
+echo 'copying images'
 cp -R images ./build/
 echo 'copying database related files'
 cp -R database/buildSchema ./build/database/
 cp -R database/insertData ./build/database/
 cp -R database/snapshotOptions ./build/database/
 cp -R database/basic_snapshot ./build/database/
+# _snapshots needs to be created manually because not in repo (.gitignore)
+mkdir ./build/database/_snapshots
 echo 'copying import/export scripts for snapshots'
 cp -R database/*.sh build/database
 cp -R database/*.sql build/database


### PR DESCRIPTION
Forgot about this in the last PR. The _snapshots folder was only being created as part of snapshot loading, which means that it wasn't yet present in the "build" folder when trying to upload a snapshot (before loading it).

So manually added "mkdir" to create this folder as part of build process.

Tested with full docker build and snapshot upload and import.