### PR TITLE
#549 Skip record with conflicting unique fields values in template import

### DIFF
--- a/database/snapshotOptions/templateExport.json
+++ b/database/snapshotOptions/templateExport.json
@@ -14,7 +14,9 @@
     "permissionName",
     "file"
   ],
-  "tablesToUpdateOnInsertFail": ["permissionName", "permissionPolicy", "filter", "file"],
+  "//tablesToUpdateOnInsertFail": "deprecated, in favour of skipTableOnInsertFail",
+  "//skipTableOnInsertFail": "These tables have unique contraint other then ID, they will be skippped if insert fail, and any related records will reference existing record",
+  "skipTableOnInsertFail": ["permissionName", "permissionPolicy", "filter", "file"],
   "excludeTables": [],
   "insertScriptsLocale": "dev",
   "includeInsertScripts": [],

--- a/src/components/exportAndImport/importFromJson.ts
+++ b/src/components/exportAndImport/importFromJson.ts
@@ -83,6 +83,8 @@ const constructInsertAndGetter = (
     columns
   )
 
+  const resultFields = ` ${columns.map(({ columnName }) => columnName).join(' ')}`
+
   const insertQuery = `mutation ${insertMutationName} ${variableDeclarations} {
         ${insertMutationName} (
             input: {
@@ -90,13 +92,13 @@ const constructInsertAndGetter = (
                     ${keyValues}
                 }
             }
-        ) { ${singularTableName} { id } }
+        ) { ${singularTableName} { ${resultFields} } }
     }`
 
   const getRecordQuery =
     uniqueField &&
     `query ${getRecordQueryName} { 
-      ${getRecordQueryName}(${uniqueField}: "${record[uniqueField]}") { id } 
+      ${getRecordQueryName}(${uniqueField}: "${record[uniqueField]}") { ${resultFields} }
   }`
 
   const insertGetter = (gqlResult: any) => gqlResult[insertMutationName][singularTableName]

--- a/src/components/exportAndImport/importFromJson.ts
+++ b/src/components/exportAndImport/importFromJson.ts
@@ -14,7 +14,7 @@ import {
 
 const insertFromObject = async (
   records: ObjectRecords,
-  { includeTables, excludeTables, tablesToUpdateOnInsertFail = [] }: ExportAndImportOptions,
+  { includeTables, excludeTables, skipTableOnInsertFail = [] }: ExportAndImportOptions,
   preserveIds: boolean = false
 ) => {
   const databaseTables = (await getDatabaseInfo()).filter(({ isView }) => !isView)
@@ -28,7 +28,7 @@ const insertFromObject = async (
     if (!recordsForTable || recordsForTable.length === 0) continue
 
     for (let record of recordsForTable) {
-      const { insertQuery, updateQuery, insertGetter, updateGetter, variables } =
+      const { insertQuery, getRecordQuery, insertGetter, getRecordGetter, variables } =
         constructInsertAndGetter(record, table, insertedRecords, preserveIds)
       let result = {}
       let row = {}
@@ -36,9 +36,15 @@ const insertFromObject = async (
         result = await databaseConnect.gqlQuery(insertQuery, variables)
         row = insertGetter(result)
       } catch (e) {
-        if (!tablesToUpdateOnInsertFail.includes(tableName)) throw e
-        result = await databaseConnect.gqlQuery(updateQuery, variables)
-        row = updateGetter(result)
+        // If insert failed and table is in skipTableOnInsertFail, this is likely due to unique constraint (i.e. permissionName.name or filter.code)
+        // in this case record should be skipped but we still want to get id for existing record so that we can link related records (i.e templatePermission)
+        if (!skipTableOnInsertFail.includes(tableName)) throw e
+        if (!getRecordQuery)
+          throw new Error(
+            `insert query failed but no unique field found to construct getter query, insert query was: ${insertQuery}`
+          )
+        result = await databaseConnect.gqlQuery(getRecordQuery, variables)
+        row = getRecordGetter(result)
       }
 
       if (!insertedRecords[tableName]) insertedRecords[tableName] = []
@@ -58,18 +64,20 @@ const constructInsertAndGetter = (
   const foreignKeyReplacements = getForeignKeyReplacements(record, columns, insertedRecords)
   const insertableValues: ObjectRecord = {}
   const values = { ...record, ...foreignKeyReplacements }
+  let uniqueField: string | undefined
 
-  columns.forEach(({ isPrimary, isGenerated, columnName }) => {
+  columns.forEach(({ isPrimary, isGenerated, isUnique, columnName }) => {
     if (!preserveIds && isPrimary) return
     if (isGenerated) return
     if (values[columnName] === undefined) return
+    if (isUnique) uniqueField = columnName
     insertableValues[columnName] = values[columnName]
   })
 
   // Postgraphile will make all plural table names singular for mutations
   const singularTableName = singular(tableName)
   const insertMutationName = camelCase(`create ${singularTableName}`)
-  const updateMutationName = camelCase(`update ${singularTableName}`)
+  const getRecordQueryName = camelCase(`update ${singularTableName}_on_${uniqueField}`)
   const { keyValues, variables, variableDeclarations } = getInsertKeyValues(
     insertableValues,
     columns
@@ -89,20 +97,19 @@ const constructInsertAndGetter = (
         ) { ${resultQuery} }
     }`
 
-  const updateQuery = `mutation ${updateMutationName} ${variableDeclarations} {
-      ${updateMutationName} (
-          input: {
-              patch: {
-                  ${keyValues}
-              },
-              id: ${record.id}
-          }
-      ) { ${resultQuery} }
+  const getRecordQuery =
+    uniqueField &&
+    `query ${getRecordQueryName} { 
+    ${getRecordQueryName}(code: "${record[uniqueField]})" {
+        nodes {
+            ${columns.map(({ columnName }) => columnName).join(' ')}
+        }
+    }
   }`
 
   const insertGetter = (gqlResult: any) => gqlResult[insertMutationName][singularTableName]
-  const updateGetter = (gqlResult: any) => gqlResult[updateMutationName][singularTableName]
-  return { insertQuery, updateQuery, insertGetter, updateGetter, variables }
+  const getRecordGetter = (gqlResult: any) => gqlResult[getRecordQueryName][getRecordQueryName]
+  return { insertQuery, getRecordQuery, insertGetter, getRecordGetter, variables }
 }
 
 const getForeignKeyReplacements = (

--- a/src/components/exportAndImport/types.ts
+++ b/src/components/exportAndImport/types.ts
@@ -32,7 +32,9 @@ export type ExportAndImportOptions = {
   insertScriptsLocale: string
   includeInsertScripts: string[]
   excludeInsertScripts: string[]
+  // tablesToUpdateOnInsertFail is deprecated, but values are still required (for existing snapshots), they key is change to skipTableOnInsertFail in useSnapshot
   tablesToUpdateOnInsertFail: string[]
+  skipTableOnInsertFail: string[]
 }
 
 export type ObjectRecord = { [columnName: string]: any }

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -63,6 +63,15 @@ const useSnapshot: SnapshotOperation = async ({
     return { success: false, message: 'error while loading snapshot', error: e.toString() }
   }
 }
+
+const convertDeprecated = (options: ExportAndImportOptions) => {
+  // see comment in ExportAndImportOptions type
+  return {
+    ...options,
+    skipTableOnInsertFail: options.skipTableOnInsertFail || options.tablesToUpdateOnInsertFail,
+  }
+}
+
 const getOptions = async (
   snapshotFolder: string,
   optionsName?: string,
@@ -70,7 +79,7 @@ const getOptions = async (
 ) => {
   if (options) {
     console.log('use options passed as a parameter')
-    return options
+    return convertDeprecated(options)
   }
   let optionsFile = path.join(snapshotFolder, `${OPTIONS_FILE_NAME}.json`)
 
@@ -80,7 +89,7 @@ const getOptions = async (
     encoding: 'utf-8',
   })
 
-  return JSON.parse(optionsRaw) as ExportAndImportOptions
+  return convertDeprecated(JSON.parse(optionsRaw) as ExportAndImportOptions)
 }
 
 const initiliseDatabase = async (


### PR DESCRIPTION
Fixes: #549 

### Changes

* Changed tablesToUpdateOnInsertFail import/export option to skipTableOnInsertFail (made it backwards compatible with existing snapshots)
* Instead of trying to update on conflict, just query for that record (need id from that record to make sure we insert related record correctly

### Testing

I've tested a few scenarios, import doesn't show any errors, and seems logically correct, would be good to give it another test spin, to make sure correct filter joins and template permission are associated with corresponding filter and permission names, for those that conflict