### PR TITLE
#553 Snapshots -- clear files option

### DIFF
--- a/database/basic_snapshot/options.json
+++ b/database/basic_snapshot/options.json
@@ -1,17 +1,16 @@
 {
- "filters": {},
- "includeTables": [],
- "excludeTables": [
-  "actionQueue",
-  "triggerQueue",
-  "applicationListShape",
-  "elementTypePlugin",
-  "notification"
- ],
- "shouldReInitialise": true,
- "insertScriptsLocale": "dev",
- "includeInsertScripts": [
-  "none"
- ],
- "excludeInsertScripts": []
+  "filters": {},
+  "includeTables": [],
+  "excludeTables": [
+    "actionQueue",
+    "triggerQueue",
+    "applicationListShape",
+    "elementTypePlugin",
+    "notification"
+  ],
+  "shouldReInitialise": true,
+  "insertScriptsLocale": "dev",
+  "includeInsertScripts": ["none"],
+  "excludeInsertScripts": [],
+  "resetFiles": true
 }

--- a/database/snapshotOptions/applicationData.json
+++ b/database/snapshotOptions/applicationData.json
@@ -18,5 +18,6 @@
   "shouldReInitialise": true,
   "insertScriptsLocale": "dev",
   "includeInsertScripts": [],
-  "excludeInsertScripts": ["07_review_assignments.js", "06_applications_D_reviewTest.js"]
+  "excludeInsertScripts": ["07_review_assignments.js", "06_applications_D_reviewTest.js"],
+  "resetFiles": false
 }

--- a/database/snapshotOptions/default.json
+++ b/database/snapshotOptions/default.json
@@ -11,5 +11,6 @@
   "shouldReInitialise": true,
   "insertScriptsLocale": "dev",
   "includeInsertScripts": ["none"],
-  "excludeInsertScripts": []
+  "excludeInsertScripts": [],
+  "resetFiles": true
 }

--- a/database/snapshotOptions/exampleSingleTemplateExport.json
+++ b/database/snapshotOptions/exampleSingleTemplateExport.json
@@ -13,5 +13,6 @@
   "excludeTables": [],
   "insertScriptsLocale": "dev",
   "includeInsertScripts": [],
-  "excludeInsertScripts": []
+  "excludeInsertScripts": [],
+  "resetFiles": false
 }

--- a/database/snapshotOptions/templateExport.json
+++ b/database/snapshotOptions/templateExport.json
@@ -20,5 +20,6 @@
   "excludeTables": [],
   "insertScriptsLocale": "dev",
   "includeInsertScripts": [],
-  "excludeInsertScripts": []
+  "excludeInsertScripts": [],
+  "resetFiles": false
 }

--- a/src/components/exportAndImport/types.ts
+++ b/src/components/exportAndImport/types.ts
@@ -35,6 +35,7 @@ export type ExportAndImportOptions = {
   // tablesToUpdateOnInsertFail is deprecated, but values are still required (for existing snapshots), they key is change to skipTableOnInsertFail in useSnapshot
   tablesToUpdateOnInsertFail: string[]
   skipTableOnInsertFail: string[]
+  resetFiles: boolean
 }
 
 export type ObjectRecord = { [columnName: string]: any }

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -35,7 +35,11 @@ const useSnapshot: SnapshotOperation = async ({
     const snapshotObject = JSON.parse(snapshotRaw)
 
     if (options.shouldReInitialise) {
-      await initiliseDatabase(options, snapshotFolder)
+      await initialiseDatabase(options, snapshotFolder)
+    }
+
+    if (options.resetFiles) {
+      execSync(`rm -rf ${FILES_FOLDER}/*`)
     }
 
     console.log('inserting from snapshot ... ')
@@ -96,7 +100,7 @@ const getOptions = async (
   return convertDeprecated(JSON.parse(optionsRaw) as ExportAndImportOptions)
 }
 
-const initiliseDatabase = async (
+const initialiseDatabase = async (
   { insertScriptsLocale, includeInsertScripts, excludeInsertScripts }: ExportAndImportOptions,
   snapshotFolder: string
 ) => {


### PR DESCRIPTION
Fixes #553  

Added the option "resetFiles", and added it to existing "snapshotOptions" files:
- for full system snapshots ("default"), files folder is cleared on import
- for templates, individual templates, application data, files folder is NOT cleared on import

For existing snapshots (that don't have this parameter in their options file), they WON'T clear files (i.e. default: false)

We should add this option to current demo snapshot.

(Fixed a spelling error in "initialiseDatabase" function name as well)