### PR TITLE
#579 Better error handling for Email failure

### DIFF
--- a/plugins/action_send_notification/src/sendNotification.ts
+++ b/plugins/action_send_notification/src/sendNotification.ts
@@ -37,6 +37,14 @@ const sendNotification: ActionPluginType = async ({ parameters, applicationData,
     },
   })
 
+  if (!email) {
+    console.log('Warning: no email address(es) provided')
+    return {
+      status: ActionQueueStatus.Fail,
+      error_log: 'Email address(es) not supplied',
+    }
+  }
+
   try {
     const emailAddressString = stringifyEmailRecipientsList(email)
 
@@ -75,6 +83,11 @@ const sendNotification: ActionPluginType = async ({ parameters, applicationData,
             db.notificationEmailSent(notificationResult.id)
           }
         })
+        .catch((err) =>
+          console.log(
+            `Email sending FAILED: ${err.message}\nCheck "email_sent" field in "notification" table`
+          )
+        )
     }
 
     // NOTE: Because sending email happens asynchronously, the output object


### PR DESCRIPTION
Fix #579 

Added two additional protections:
- Checks for email address at start of action, returns FAIL if not present
- The asynchrounous "sendEmail" function has "catch" block, which will set log any email failure error, and NOT crash the server (for example, if you pass an illegal email address, or a mail server problem)

Easiest way to test is use the /run-action endpoint

This should work okay:
```
{
    "actionCode": "sendNotification",
    "applicationId": 2,
    "parameters": {
        "email": "<put a proper email address here>",
        "subject": "Test email",
        "message": "Hello!"
    }
}
```

This should cause a failed action (with Fail response):
```
{
    "actionCode": "sendNotification",
    "applicationId": 2,
    "parameters": {
        "subject": "Test email",
        "message": "Hello!"
    }
}
```

And this will show as a "SUCCESS" action (notification was created), but will console log error on email send, and the "email_sent" field on notification table will remain "false" (but most importantly, doesn't crash server)
```
{
    "actionCode": "sendNotification",
    "applicationId": 2,
    "parameters": {
        "email": "bademailadress",
        "subject": "Test email",
        "message": "Hello!"
    }
}
```