### PR TITLE
#1007B applicationData endpoint for TemplateBuilder

### DIFF
--- a/src/components/actions/runAction.ts
+++ b/src/components/actions/runAction.ts
@@ -3,10 +3,9 @@ import { getApplicationData } from './getApplicationData'
 import { combineRequestParams } from '../utilityFunctions'
 import DBConnect from '../databaseConnect'
 
-const routeRunAction = async (request: any, reply: any) => {
+export const routeRunAction = async (request: any, reply: any) => {
   const { actionCode, applicationId, reviewId, parameters } = combineRequestParams(request, 'camel')
   const applicationData = applicationId ? await getApplicationData({ applicationId, reviewId }) : {}
-  // console.log('applicationData', applicationData)
   const actionResult = await actionLibrary[actionCode]({
     parameters,
     applicationData,
@@ -15,4 +14,7 @@ const routeRunAction = async (request: any, reply: any) => {
   return reply.send(actionResult)
 }
 
-export default routeRunAction
+export const routeGetApplicationData = async (request: any, reply: any) => {
+  const { applicationId } = combineRequestParams(request, 'camel')
+  reply.send(await getApplicationData({ applicationId: Number(applicationId) }))
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import {
   filesFolder,
 } from './components/files/fileHandler'
 import { getAppEntryPointDir, objectKeysToSnakeCase } from './components/utilityFunctions'
-import routeRunAction from './components/actions/runAction'
+import { routeRunAction, routeGetApplicationData } from './components/actions/runAction'
 import config from './config'
 import lookupTableRoutes from './lookup-table/routes'
 import snapshotRoutes from './components/snapshots/routes'
@@ -34,7 +34,7 @@ require('dotenv').config()
 // Fastify server
 
 const startServer = async () => {
-  await loadActionPlugins() // Connects to Database and listens for Triggers
+  // await loadActionPlugins() // Connects to Database and listens for Triggers
 
   createFilesFolder()
 
@@ -107,6 +107,7 @@ const startServer = async () => {
         server.register(snapshotRoutes, { prefix: '/snapshot' })
         server.get('/updateRowPolicies', routeUpdateRowPolicies)
         server.post('/run-action', routeRunAction)
+        server.get('/get-application-data', routeGetApplicationData)
         done()
       },
       { prefix: '/admin' }

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,7 @@ require('dotenv').config()
 // Fastify server
 
 const startServer = async () => {
-  // await loadActionPlugins() // Connects to Database and listens for Triggers
+  await loadActionPlugins() // Connects to Database and listens for Triggers
 
   createFilesFolder()
 


### PR DESCRIPTION
Just adds additional endpoint `/admin/get-application-data` so TemplateBuilder's Actions editor can properly evaluate parameters in the UI.

(Required for https://github.com/openmsupply/application-manager-web-app/issues/1007 -- front-end PR coming soon)