### PR TITLE
#379 Authentication in Evaluator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ src/modules/expression-evaluator/expression-evaluate-gui/src/expression-evaluato
 #Snapshots working folder
 database/_snapshots
 database/snapshot_path_aliases.json
+
+#Other secrets
+testSecrets.json

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -4,7 +4,7 @@ This module is in `src/modules/expression-evaluator`, structured as its own pack
 
 The current build of the module is published to Github packages so it can be easily imported into both front- and back-end projects. See [Installation](#installation) at the end of this page for instructions on how to make it work in your environment, or [Development](#development) for information on further development of the module, including a browser-based GUI expression builder.
 
-Run `yarn test` to see it in action.
+Run `yarn test` to see it in action. (See [Testing section](#testing) for more info)
 
 ---
 
@@ -35,7 +35,10 @@ For more complex lookups, we would hide the complexity from the user in the Temp
 <!-- toc -->
 <!-- generated with markdown-toc -->
 
+- [(Dynamic) Query/Expression Syntax](#dynamic-queryexpression-syntax)
+  - [Contents](#contents)
 - [Structure](#structure)
+  - [type](#type)
 - [Operators](#operators)
   - [AND](#and)
   - [OR](#or)
@@ -50,14 +53,18 @@ For more complex lookups, we would hide the complexity from the user in the Temp
   - [graphQL](#graphql)
   - [GET](#get)
   - [POST](#post)
-  - [buildObject](#buildObject)
+    - [Authentication](#authentication)
+  - [buildObject](#buildobject)
 - [Usage](#usage)
+    - [`expression`](#expression)
+    - [`parameters`](#parameters)
 - [Examples](#examples)
 - [To Do](#to-do)
 - [Installation](#installation)
+- [Testing](#testing)
 - [Development](#development)
-  - [Publishing a new version of the package](#publishing-a-new-version-of-the-package)
-  - [GUI expression builder](#gui-expression-builder)
+    - [Publishing a new version of the package](#publishing-a-new-version-of-the-package)
+    - [GUI expression builder](#gui-expression-builder)
 
 <!-- tocstop -->
 
@@ -288,7 +295,7 @@ Performs queries on connected GraphQL interface.
 
 ## GET
 
-Performs http GET requests to public API endpoints.
+Performs http GET requests to API endpoints, with optional authentication.
 
 - Input: _(note: basically the same as GraphQL)_
   - 1st child node returns a **string** containing the url of the API endpoint
@@ -337,6 +344,28 @@ This expression queries our `/login` endpoint to check a user's credentials, and
   ],
 }
 ```
+
+### Authentication
+
+The `GET`, `POST`, and `GraphQL` operators may require authentication for the endpoints they are querying, such as our own [API](API.md). This can be achieved in a couple of different ways.
+
+1. Pass the authentication information as part of the [parameters](#parameters) `headers` field. For example, a JWT authentication might be:  
+    ```
+    headers: {
+      Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoiZGFydGhfdmFkZXIifQ.UT8qpoNVJGam4HEasxQdJ7tiYC2UzvIGcu_9OUMLJ1k"
+    }
+    ```  
+    In the front-end app, all evaluator queries use this mechanism to pass the current user's JWT, and this should be sufficient for most purposes. It's only if you require sending different headers, or need to dynamically build an authentication token, or have queries to external authenticated APIs, that you might need this second option:
+
+2. HTTP headers can be baked into each query by over-riding the "url" node of API/GraphQL queries. As described above, the "url" node normally expects a string url. However, you can also provided this node as an object with the following structure:  
+    ```
+    {
+      url: "<url-string-as-above>",
+      headers: <headers-object-as-above>
+    }
+    ```
+    In this case, the evaluator will parse the url and headers from this node and continue as normal, but the `headers` object will take priority over any that may be included in `parameters`. The `headers` object can be dynamically created using the [`buildObject`](#buildobject) operator if required. See the test suite query `testData.APIisUniqueWithHeader` for an example of how to do this.
+
 
 ## buildObject
 
@@ -432,6 +461,7 @@ The query evaluator is implemented in the `evaluateExpression` function:
 - `pgConnection: <postGresConnect object>` (or any valid PostGres connection object, e.g. `Client` from `node-postgres`)
 - `graphQLConnection: { fetch: <fetch object>, endpoint: <URL of GraphQL endpoint>}` -- connection information for a local GraphQL endpoint. Only required if expression contains **graphQL** operator.
 - `APIfetch: <fetch object>` -- required if the API operator is being used. (Note: the reason this must be passed in rather than having the module use `fetch` directly is so it can work in both front- and back-end. The browser provides a native `fetch` method, but this isn't available in Node, which requires the `node-fetch` package. So in order to work in both, the module expects the appropriate variant of the fetch object to be passed in.)
+- `headers: <HTTP request headers object>` -- optional headers for API or GraphQL requests, such as Authentication tokens. See [Authentication](#authentication) for more information.
 
 # Examples
 
@@ -627,6 +657,29 @@ To update to the latest release of the package, run:
 `yarn upgrade @openmsupply/expression-evaluator`
 
 <a name="development"></a>
+
+# Testing
+
+There is a [Jest](https://jestjs.io/) test suite for the expression evaluator included in the server repo. It can be run using:
+
+```
+ yarn test ./src/modules/expression-evaluator/src/evaluateExpression.test.ts 
+```
+
+(Or just `yarn test ./src/evaluateExpression.test.ts` from within evaluator subfolder )
+
+However, for the tests to work you'll need two things:
+
+1. Load the [snapshot](Snapshots.md) called `evaluator_test` from the private templates repo (in `/dev/other`)
+2. You'll need to provide authentication JWTs for certain tests. The test suite is expecting a file called `testSecrets.json` in the evaluator /src folder, with the following info:  
+```
+{
+  "nonRegisteredAuth": "Bearer <nonRegistered-JWT-token>",
+  "adminAuth": "Bearer <admin-JWT-token>"
+}
+
+```  
+This secrets file is *not* included in any repo for security reasons, so you'll need to create it yourself.
 
 # Development
 

--- a/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
+++ b/src/modules/expression-evaluator/expression-evaluate-gui/src/App.js
@@ -52,6 +52,7 @@ function App() {
   )
   const [objects, setObjects] = useState()
   const [isObjectsValid, setIsObjectsValid] = useState(true)
+  const [jwtToken, setJwtToken] = useState(localStorage.getItem('JWT'))
   const [strictJSONInput, setStrictJSONInput] = useState(false)
   const [strictJSONObjInput, setStrictJSONObjInput] = useState(false)
   const [evaluatorSelection, setEvaluatorSelection] = useState(
@@ -73,11 +74,13 @@ function App() {
     } catch {
       cleanInput = { value: '< Invalid input >' }
     }
+    const headers = jwtToken ? { Authorization: 'Bearer ' + jwtToken } : {}
     evaluate(cleanInput, {
       objects: objects,
       pgConnection: pgInterface,
       graphQLConnection: { fetch: fetchNative, endpoint: graphQLendpoint },
       APIfetch: fetchNative,
+      headers,
     })
       .then((res) => {
         const output = typeof res === 'object' ? JSON.stringify(res, null, 2) : String(res)
@@ -89,7 +92,7 @@ function App() {
         setResultType('error')
       })
     localStorage.setItem('inputText', input)
-  }, [input, objectsInput, objects, evaluatorSelection])
+  }, [input, objectsInput, objects, evaluatorSelection, jwtToken])
 
   // Try and turn object(s) input string into object array
   useEffect(() => {
@@ -115,6 +118,11 @@ function App() {
 
   const handleObjectsChange = (event) => {
     setObjectsInput(event.target.value)
+  }
+
+  const handleJWTChange = (event) => {
+    setJwtToken(event.target.value)
+    localStorage.setItem('JWT', event.target.value)
   }
 
   const handleSelect = (event) => {
@@ -224,16 +232,29 @@ function App() {
           multiline
           fullWidth
           spellCheck="false"
-          rows={30}
+          rows={21}
           value={objectsInput}
           variant="outlined"
           onChange={handleObjectsChange}
         />
-        {!isObjectsValid && (
-          <Typography className="invalid-warning" style={{ color: 'red' }}>
-            Invalid object input
-          </Typography>
-        )}
+        <Typography className="invalid-warning" style={{ color: 'red' }}>
+          {!isObjectsValid ? 'Invalid object input' : ''}
+        </Typography>
+        <TextField
+          className={classes.margin}
+          id="jwt-input"
+          label="JWT Token"
+          InputProps={{
+            classes: { input: classes.textField },
+          }}
+          multiline
+          fullWidth
+          spellCheck="false"
+          rows={5}
+          value={jwtToken}
+          variant="outlined"
+          onChange={handleJWTChange}
+        />
       </Grid>
       <Grid item xs className={classes.margin}>
         <h1>Input</h1>

--- a/src/modules/expression-evaluator/package.json
+++ b/src/modules/expression-evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmsupply/expression-evaluator",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Module to evaluate dynamic expressions for the openMsupply Application Manager project",
   "main": "lib/evaluateExpression.js",
   "types": "lib/evaluateExpression.d.ts",

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -531,17 +531,17 @@ test('Test GraphQL -- get single application name', () => {
   })
 })
 
-// test('Test GraphQL -- get single application name with custom query authorization', () => {
-//   return evaluateExpression(testData.simpleGraphQLCustomHeader, {
-//     objects: { secrets },
-//     graphQLConnection: {
-//       fetch: fetch,
-//       endpoint: graphQLendpoint,
-//     },
-//   }).then((result: any) => {
-//     expect(result).toEqual('Company Registration - S-ECL-0011')
-//   })
-// })
+test('Test GraphQL -- get single application name with custom query authorization', () => {
+  return evaluateExpression(testData.simpleGraphQLCustomHeader, {
+    objects: { secrets },
+    graphQLConnection: {
+      fetch: fetch,
+      endpoint: graphQLendpoint,
+    },
+  }).then((result: any) => {
+    expect(result).toEqual('Company Registration - S-ECL-0011')
+  })
+})
 
 test('Test GraphQL -- List of Application Names', () => {
   return evaluateExpression(testData.GraphQL_listOfApplications, {

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -413,6 +413,15 @@ test('GET: Check username is unique', () => {
   })
 })
 
+test('GET: Check username is unique using custom query authentication', () => {
+  return evaluateExpression(testData.APIisUniqueWithHeaders, {
+    objects: { secrets },
+    APIfetch: fetch,
+  }).then((result: any) => {
+    expect(result).toEqual({ unique: false, message: '' })
+  })
+})
+
 test('GET: Lookup ToDo in online testing API', () => {
   return evaluateExpression(testData.onlineTestAPI, {
     APIfetch: fetch,
@@ -521,6 +530,18 @@ test('Test GraphQL -- get single application name', () => {
     expect(result).toEqual('Company Registration - S-ECL-0011')
   })
 })
+
+// test('Test GraphQL -- get single application name with custom query authorization', () => {
+//   return evaluateExpression(testData.simpleGraphQLCustomHeader, {
+//     objects: { secrets },
+//     graphQLConnection: {
+//       fetch: fetch,
+//       endpoint: graphQLendpoint,
+//     },
+//   }).then((result: any) => {
+//     expect(result).toEqual('Company Registration - S-ECL-0011')
+//   })
+// })
 
 test('Test GraphQL -- List of Application Names', () => {
   return evaluateExpression(testData.GraphQL_listOfApplications, {

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -3,6 +3,7 @@
 import evaluateExpression from './evaluateExpression'
 import { testData } from './evaluateExpressionTestData'
 import config from './config.json'
+import secrets from './testSecrets.json'
 
 const { Client } = require('pg')
 
@@ -404,6 +405,9 @@ test('String substitution - some parameters empty strings', () => {
 test('GET: Check username is unique', () => {
   return evaluateExpression(testData.APIisUnique, {
     APIfetch: fetch,
+    headers: {
+      Authorization: secrets.nonRegisteredAuth,
+    },
   }).then((result: any) => {
     expect(result).toEqual({ unique: true, message: '' })
   })
@@ -447,7 +451,7 @@ test('POST: Check user login credentials', () => {
 test('Test Postgres lookup single string', () => {
   return evaluateExpression(testData.getApplicationName, { pgConnection: pgConnect }).then(
     (result: any) => {
-      expect(result).toBe('Test Review -- Vitamin C')
+      expect(result).toBe('Company License -- Modern medicines or Medical devices - S-GZY-0010')
     }
   )
 })
@@ -456,13 +460,11 @@ test('Test Postgres get array of template names', () => {
   return evaluateExpression(testData.getListOfTemplates, { pgConnection: pgConnect }).then(
     (result: any) => {
       expect(result).toEqual([
-        'Edit User Details',
         'User Registration',
-        'Demo -- Feature Showcase',
-        'Company Registration',
-        'Test -- Review Process',
-        'Drug Registration - General Medicines Procedure',
-        'Join Company',
+        'Edit User Details',
+        'Grant User Permissions',
+        'Add User to Company',
+        'Company License -- Modern medicines or Medical devices',
       ])
     }
   )
@@ -471,7 +473,7 @@ test('Test Postgres get array of template names', () => {
 test('Test Postgres get Count of templates', () => {
   return evaluateExpression(testData.countTemplates, { pgConnection: pgConnect }).then(
     (result: any) => {
-      expect(result).toEqual(7)
+      expect(result).toEqual(24)
     }
   )
 })
@@ -480,13 +482,11 @@ test('Test Postgres get template names -- no type', () => {
   return evaluateExpression(testData.getListOfTemplates_noType, { pgConnection: pgConnect }).then(
     (result: any) => {
       expect(result).toEqual([
-        { name: 'Edit User Details' },
         { name: 'User Registration' },
-        { name: 'Demo -- Feature Showcase' },
-        { name: 'Company Registration' },
-        { name: 'Test -- Review Process' },
-        { name: 'Drug Registration - General Medicines Procedure' },
-        { name: 'Join Company' },
+        { name: 'Edit User Details' },
+        { name: 'Grant User Permissions' },
+        { name: 'Add User to Company' },
+        { name: 'Company License -- Modern medicines or Medical devices' },
       ])
     }
   )
@@ -497,12 +497,11 @@ test('Test Postgres get application list with IDs', () => {
     pgConnection: pgConnect,
   }).then((result: any) => {
     expect(result).toEqual([
-      { id: 4000, name: 'Test Review -- Vitamin C' },
-      { id: 4001, name: 'Test Review -- Vitamin B' },
-      { id: 4002, name: 'Test Review -- Amoxicillin' },
-      { id: 4003, name: 'Test Review -- Ibuprofen' },
-      { id: 4004, name: 'Test Review -- Paracetamol' },
-      { id: 4005, name: 'Test Review -- Oxygen' },
+      { id: 18, name: 'Company License -- Modern medicines or Medical devices - S-GZY-0010' },
+      { id: 22, name: 'Company Registration - S-ECL-0011' },
+      { id: 23, name: 'Product Registration - S-WJY-0006' },
+      { id: 26, name: 'Company Registration - Pharma123' },
+      { id: 27, name: 'Company Registration - Holistic Medicine AU' },
     ])
   })
 })
@@ -515,8 +514,11 @@ test('Test GraphQL -- get single application name', () => {
       fetch: fetch,
       endpoint: graphQLendpoint,
     },
+    headers: {
+      Authorization: secrets.adminAuth,
+    },
   }).then((result: any) => {
-    expect(result).toEqual('Test Review -- Vitamin C')
+    expect(result).toEqual('Company Registration - S-ECL-0011')
   })
 })
 
@@ -525,15 +527,15 @@ test('Test GraphQL -- List of Application Names', () => {
     graphQLConnection: {
       fetch: fetch,
       endpoint: graphQLendpoint,
+      headers: {
+        Authorization: secrets.adminAuth,
+      },
     },
   }).then((result: any) => {
     expect(result).toEqual([
-      'Test Review -- Vitamin C',
-      'Test Review -- Vitamin B',
-      'Test Review -- Amoxicillin',
-      'Test Review -- Ibuprofen',
-      'Test Review -- Paracetamol',
-      'Test Review -- Oxygen',
+      'Company Registration - Advance Phamaceutical Manufacturing',
+      'Company Registration - Bayer (Pty) Ltd',
+      'Company Registration - Novartis Spain',
     ])
   })
 })
@@ -543,15 +545,15 @@ test('Test GraphQL -- List of Application Names with Ids', () => {
     graphQLConnection: {
       fetch: fetch,
       endpoint: graphQLendpoint,
+      headers: {
+        Authorization: secrets.adminAuth,
+      },
     },
   }).then((result: any) => {
     expect(result).toEqual([
-      { id: 4000, name: 'Test Review -- Vitamin C' },
-      { id: 4001, name: 'Test Review -- Vitamin B' },
-      { id: 4002, name: 'Test Review -- Amoxicillin' },
-      { id: 4003, name: 'Test Review -- Ibuprofen' },
-      { id: 4004, name: 'Test Review -- Paracetamol' },
-      { id: 4005, name: 'Test Review -- Oxygen' },
+      { id: 45, name: 'Product Registration - S-LZU-0014' },
+      { id: 46, name: 'Company License -- Modern medicines or Medical devices - S-MTC-0013' },
+      { id: 47, name: 'Product Registration - Epivir 150 mg film-coated tablet' },
     ])
   })
 })
@@ -562,17 +564,23 @@ test('Test GraphQL -- Get list of templates -- no return node specifed', () => {
       fetch: fetch,
       endpoint: graphQLendpoint,
     },
+    headers: {
+      Authorization: secrets.adminAuth,
+    },
   }).then((result: any) => {
     expect(result).toEqual({
       templates: {
         edges: [
-          { node: { name: 'Edit User Details' } },
-          { node: { name: 'User Registration' } },
-          { node: { name: 'Demo -- Feature Showcase' } },
-          { node: { name: 'Company Registration' } },
-          { node: { name: 'Test -- Review Process' } },
-          { node: { name: 'Drug Registration - General Medicines Procedure' } },
-          { node: { name: 'Join Company' } },
+          {
+            node: {
+              name: 'Product Registration',
+            },
+          },
+          {
+            node: {
+              name: 'Company Registration',
+            },
+          },
         ],
       },
     })
@@ -586,19 +594,7 @@ test('Test GraphQL -- Count templates -- passing params as object option', () =>
       endpoint: graphQLendpoint,
     },
   }).then((result: any) => {
-    expect(result).toEqual(7)
-  })
-})
-
-test('Test GraphQL -- count Sections on current Application', () => {
-  return evaluateExpression(testData.GraphQL_CountApplicationSections, {
-    objects: { application: testData.application },
-    graphQLConnection: {
-      fetch: fetch,
-      endpoint: graphQLendpoint,
-    },
-  }).then((result: any) => {
-    expect(result).toEqual(2)
+    expect(result).toEqual(24)
   })
 })
 
@@ -609,8 +605,11 @@ test('Test GraphQL -- count Responses on current Application - using empty url (
       fetch: fetch,
       endpoint: graphQLendpoint,
     },
+    headers: {
+      Authorization: secrets.adminAuth,
+    },
   }).then((result: any) => {
-    expect(result).toEqual(10)
+    expect(result).toEqual(20)
   })
 })
 
@@ -647,8 +646,6 @@ test('Test GraphQL -- Check result of field can be null', () => {
   })
 })
 
-// TO-DO: Test with multiple variables and dynamic values
-
 // More complex combinations
 
 test('Test concatenate user First and Last names', () => {
@@ -675,6 +672,9 @@ test('Test email validation -- email is unique and is valid email', () => {
   return evaluateExpression(testData.emailValidation, {
     objects: { form: testData.form },
     APIfetch: fetch,
+    headers: {
+      Authorization: secrets.nonRegisteredAuth,
+    },
   }).then((result: any) => {
     expect(result).toBe(true)
   })
@@ -688,16 +688,6 @@ test('Test visibility condition -- Answer to Q1 is Drug Registration and user be
     expect(result).toBe(true)
   })
 })
-
-// The following need more data in database and schema refinements before they can be implemented:
-
-// test('Test Trigger condition -- Stage = 1 (Screening) and All Questions are approved', () => {
-//   return evaluateExpression(testData.complex2, {
-//     application: testData.application,
-//   }).then((result: any) => {
-//     expect(result).toBe(true);
-//   });
-// });
 
 // Non-standard input expressions
 

--- a/src/modules/expression-evaluator/src/evaluateExpression.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.ts
@@ -158,7 +158,8 @@ const evaluateExpression: EvaluateExpression = async (inputQuery, params = defau
 
     case 'graphQL':
       if (!params.graphQLConnection) throw new Error('No GraphQL database connection provided')
-      return processGraphQL(childrenResolved, params.graphQLConnection, params?.headers)
+      const gqlHeaders = params?.headers ?? params.graphQLConnection.headers
+      return processGraphQL(childrenResolved, params.graphQLConnection, gqlHeaders)
 
     case 'buildObject':
       return buildObject(inputQuery as BuildObjectQuery, evaluationExpressionInstance)

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -688,6 +688,45 @@ testData.APIisUnique = {
   operator: 'GET',
   children: ['http://localhost:8080/api/check-unique', ['type', 'value'], 'username', 'druglord'],
 }
+
+testData.APIisUniqueWithHeaders = {
+  operator: 'graphQL',
+  children: [
+    `query App($appId:Int!) {
+      application(id: $appId) {
+        name
+      }
+    }`,
+    {
+      operator: 'buildObject',
+      properties: [
+        {
+          key: 'url',
+          value: '',
+        },
+        {
+          key: 'headers',
+          value: {
+            operator: 'buildObject',
+            properties: [
+              {
+                key: 'Authorization',
+                value: {
+                  operator: 'objectProperties',
+                  children: ['secrets.adminAuth'],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    ['appId'],
+    22,
+    'application.name',
+  ],
+}
+
 testData.onlineTestAPI = {
   operator: 'GET',
   children: ['https://jsonplaceholder.typicode.com/todos/1', [], 'title'],
@@ -777,6 +816,21 @@ testData.getListOfApplications_withId = {
 // GraphQL operator
 
 testData.simpleGraphQL = {
+  operator: 'graphQL',
+  children: [
+    `query App($appId:Int!) {
+      application(id: $appId) {
+        name
+      }
+    }`,
+    'graphQLEndpoint',
+    ['appId'],
+    22,
+    'application.name',
+  ],
+}
+
+testData.simpleGraphQLCustomHeader = {
   operator: 'graphQL',
   children: [
     `query App($appId:Int!) {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -574,7 +574,7 @@ testData.form2 = {
 }
 
 testData.application = {
-  id: 4000,
+  id: 47,
   name: 'Test Review -- Vitamin C',
   status: 'Submitted',
   stage: 1,
@@ -704,7 +704,7 @@ testData.APIlogin = {
   children: [
     'http://localhost:8080/api/public/login',
     ['username', 'password'],
-    'js',
+    'jane_smith',
     '123456',
     'success',
   ],
@@ -731,7 +731,7 @@ testData.getApplicationName = {
       value: 'SELECT name FROM application WHERE template_id = $1 LIMIT 1',
     },
     {
-      value: 5,
+      value: 28,
     },
   ],
 }
@@ -741,7 +741,7 @@ testData.getListOfTemplates = {
   operator: 'pgSQL',
   children: [
     {
-      value: 'SELECT name FROM template',
+      value: 'SELECT name FROM template LIMIT 5',
     },
   ],
 }
@@ -760,7 +760,7 @@ testData.getListOfTemplates_noType = {
   operator: 'pgSQL',
   children: [
     {
-      value: 'SELECT name FROM template',
+      value: 'SELECT name FROM template LIMIT 5',
     },
   ],
 }
@@ -769,7 +769,7 @@ testData.getListOfApplications_withId = {
   operator: 'pgSQL',
   children: [
     {
-      value: 'SELECT id, name FROM application',
+      value: 'SELECT id, name FROM application LIMIT 5',
     },
   ],
 }
@@ -786,7 +786,7 @@ testData.simpleGraphQL = {
     }`,
     'graphQLEndpoint',
     ['appId'],
-    4000,
+    22,
     'application.name',
   ],
 }
@@ -795,7 +795,7 @@ testData.GraphQL_listOfApplications = {
   operator: 'graphQL',
   children: [
     `query Apps {
-      applications {
+      applications(first: 3, offset: 10) {
         nodes {
           name
         }
@@ -811,7 +811,7 @@ testData.GraphQL_listOfApplicationsWithId = {
   operator: 'graphQL',
   children: [
     `query Apps {
-      applications {
+      applications(first: 3, offset: 20) {
         nodes {
           name
           id
@@ -828,7 +828,7 @@ testData.GraphQL_listOfTemplates_noReturnSpecified = {
   operator: 'graphQL',
   children: [
     `query Templates {
-      templates {
+      templates(first: 2, offset: 10) {
         edges {
           node {
             name
@@ -857,34 +857,10 @@ testData.GraphQL_CountTemplates_objectParamsOption = {
   ],
 }
 
-testData.GraphQL_CountApplicationSections = {
-  operator: 'graphQL',
-  children: [
-    `query SectionCount($appId:Int!) {
-      application(id: $appId) {
-        id
-        template {
-          name
-        }
-        applicationSections {
-          totalCount
-        }
-      }
-    }`,
-    'graphQLEndpoint',
-    ['appId'],
-    {
-      operator: 'objectProperties',
-      children: ['application.id'],
-    },
-    'application.applicationSections.totalCount',
-  ],
-}
-
 testData.GraphQL_CountApplicationResponses = {
   operator: 'graphQL',
   children: [
-    `query SectionCount($appId:Int!) {
+    `query ResponseCount($appId:Int!) {
       application(id: $appId) {
         applicationResponses {
           totalCount

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -686,7 +686,7 @@ testData.stringSubstitutionEmptyStringInReplacements = {
 
 testData.APIisUnique = {
   operator: 'GET',
-  children: ['http://localhost:8080/check-unique', ['type', 'value'], 'username', 'druglord'],
+  children: ['http://localhost:8080/api/check-unique', ['type', 'value'], 'username', 'druglord'],
 }
 testData.onlineTestAPI = {
   operator: 'GET',
@@ -701,7 +701,13 @@ testData.onlineArrayReturn = {
 
 testData.APIlogin = {
   operator: 'POST',
-  children: ['http://localhost:8080/login', ['username', 'password'], 'js', '123456', 'success'],
+  children: [
+    'http://localhost:8080/api/public/login',
+    ['username', 'password'],
+    'js',
+    '123456',
+    'success',
+  ],
 }
 
 // prettier-ignore
@@ -973,7 +979,7 @@ testData.emailValidation = {
     {
       operator: 'GET',
       children: [
-        'http://localhost:8080/check-unique',
+        'http://localhost:8080/api/check-unique',
         ['type', 'value'],
         'email',
         {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -690,19 +690,14 @@ testData.APIisUnique = {
 }
 
 testData.APIisUniqueWithHeaders = {
-  operator: 'graphQL',
+  operator: 'GET',
   children: [
-    `query App($appId:Int!) {
-      application(id: $appId) {
-        name
-      }
-    }`,
     {
       operator: 'buildObject',
       properties: [
         {
           key: 'url',
-          value: '',
+          value: 'http://localhost:8080/api/check-unique',
         },
         {
           key: 'headers',
@@ -713,7 +708,7 @@ testData.APIisUniqueWithHeaders = {
                 key: 'Authorization',
                 value: {
                   operator: 'objectProperties',
-                  children: ['secrets.adminAuth'],
+                  children: ['secrets.nonRegisteredAuth'],
                 },
               },
             ],
@@ -721,9 +716,9 @@ testData.APIisUniqueWithHeaders = {
         },
       ],
     },
-    ['appId'],
-    22,
-    'application.name',
+    ['type', 'value'],
+    'username',
+    'jane_smith',
   ],
 }
 
@@ -838,7 +833,30 @@ testData.simpleGraphQLCustomHeader = {
         name
       }
     }`,
-    'graphQLEndpoint',
+    {
+      operator: 'buildObject',
+      properties: [
+        {
+          key: 'url',
+          value: '',
+        },
+        {
+          key: 'headers',
+          value: {
+            operator: 'buildObject',
+            properties: [
+              {
+                key: 'Authorization',
+                value: {
+                  operator: 'objectProperties',
+                  children: ['secrets.adminAuth'],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
     ['appId'],
     22,
     'application.name',

--- a/src/modules/expression-evaluator/src/types.ts
+++ b/src/modules/expression-evaluator/src/types.ts
@@ -16,6 +16,7 @@ export interface IConnection {
 export interface IGraphQLConnection {
   fetch: Function
   endpoint: string
+  headers?: { [key: string]: string }
 }
 
 export interface IParameters {

--- a/src/modules/expression-evaluator/src/types.ts
+++ b/src/modules/expression-evaluator/src/types.ts
@@ -23,6 +23,7 @@ export interface IParameters {
   pgConnection?: IConnection
   graphQLConnection?: IGraphQLConnection
   APIfetch?: Function
+  headers?: { [key: string]: string }
 }
 
 export interface OperatorNode {


### PR DESCRIPTION
Fix #379 

Still need to update front-end to use this mechanism, but this includes:
- changes required to evaluator to handle authentication/headers
- updated test suite to use this mechanism and demonstrate custom header queries
  - Test suite now requires "evaluator_test" snapshot and an additional secrets file -- see documentation for details (@nmadruga I'll send you my testSecrets.json file on Telegram)
- updated documentation to explain the above in detail
- have also updated the GUI query builder app to allow inserting a JWT into evaluator parameters

Please see the new "Authentication" and "Testing" sections of "Query-Syntax.md" doc for detailed explanation.

The primary mechanism for providing authentication headers is pretty simple -- just add an additional "headers" field to the evaluator parameters. There is also a mechanism for providing specific/ dynamic authentication within the query itself. This is more complicated, and I'll admit it's not the most elegant way to format this info, but I think it's acceptable for a couple of reasons:
1. It needed to be backwards compatible with all existing API/GraphQL queries, so couldn't change the underlying child node structure
2. I don't actually think we need to use it right now. I'm pretty sure all front-end API queries can just use the "parameters" approach to add current user's JWT to all evaluator queries, but I've provided this option just in case I'm wrong about that.