### PR TITLE
#611 Fix for templates going to DRAFT on snapshot load

### DIFF
--- a/database/buildSchema/07_template.sql
+++ b/database/buildSchema/07_template.sql
@@ -47,6 +47,7 @@ $template_event$
 LANGUAGE plpgsql;
 
 -- FUNCTION to make sure duplicated templates have 'DRAFT' status
+--   but only if there are no other versions with 'AVAILABLE' status
 CREATE OR REPLACE FUNCTION public.set_template_to_draft ()
     RETURNS TRIGGER
     AS $template_event$
@@ -57,11 +58,32 @@ BEGIN
         FROM
             TEMPLATE
         WHERE
-            id != NEW.id AND code = NEW.code) > 0 THEN
+            id != NEW.id AND code = NEW.code AND status = 'AVAILABLE') > 0 THEN
         NEW.status = 'DRAFT';
     END IF;
     RETURN NEW;
 END
+$template_event$
+LANGUAGE plpgsql;
+
+-- FUNCTION to set 'AVAILABLE' version of template to 'DISABLED'
+-- when another is set to 'AVAILABLE'
+CREATE OR REPLACE FUNCTION public.template_status_update ()
+    RETURNS TRIGGER
+    AS $template_event$
+BEGIN
+    IF (NEW.status = 'AVAILABLE') THEN
+        UPDATE
+            public.template
+        SET
+            status = 'DISABLED'
+        WHERE
+            code = NEW.code
+            AND status = 'AVAILABLE'
+            AND id != NEW.id;
+    END IF;
+    RETURN NULL;
+END;
 $template_event$
 LANGUAGE plpgsql;
 
@@ -75,4 +97,12 @@ CREATE TRIGGER set_template_version_trigger
 CREATE TRIGGER set_template_to_draft_trigger
     BEFORE INSERT ON public.template
     FOR EACH ROW
-    EXECUTE FUNCTION public.set_template_to_draft ()
+    EXECUTE FUNCTION public.set_template_to_draft ();
+
+-- TRIGGER to ensure only one template version can be 'AVAILABLE'
+CREATE TRIGGER template_status_update_trigger
+    AFTER UPDATE OF status ON public.template
+    FOR EACH ROW
+    WHEN (NEW.status = 'AVAILABLE')
+    EXECUTE FUNCTION public.template_status_update ();
+

--- a/database/buildSchema/07_template.sql
+++ b/database/buildSchema/07_template.sql
@@ -47,7 +47,7 @@ $template_event$
 LANGUAGE plpgsql;
 
 -- FUNCTION to make sure duplicated templates have 'DRAFT' status
---   but only if there are no other versions with 'AVAILABLE' status
+--   but only if there is another version with 'AVAILABLE' status
 CREATE OR REPLACE FUNCTION public.set_template_to_draft ()
     RETURNS TRIGGER
     AS $template_event$

--- a/database/buildSchema/20_application_stage_history.sql
+++ b/database/buildSchema/20_application_stage_history.sql
@@ -29,4 +29,5 @@ CREATE TRIGGER application_stage_history_trigger
     AFTER INSERT OR UPDATE OF is_current ON public.application_stage_history
     FOR EACH ROW
     WHEN (NEW.is_current = TRUE)
-    EXECUTE FUNCTION public.stage_is_current_update ()
+    EXECUTE FUNCTION public.stage_is_current_update ();
+


### PR DESCRIPTION
Fixes #611 

Turns out this was due to the `public.set_template_to_draft` function in `template.sql` being a bit over-eager. Was supposed to make duplicated templates as DRAFT, but didn't really consider re-importing them. Have just added another condition that means it will only do this if there are no other versions with 'AVAILABLE' status.

**Additional:**

I've also added another function in here that will automatically set other "AVAILABLE" version status to "DISABLED" when you enable another version. This is consistent with what we do with "is_current" in stage/status history, and when "Outcome" is changed from "PENDING", etc., so it makes sense to enforce this at the database level. This means the front-end will be able to set a template to "AVAILABLE" without having to go and disable another version first. (Front-end PR https://github.com/openmsupply/application-manager-web-app/pull/1025)
