### PR TITLE
Build script fix

### DIFF
--- a/utils/build_all.sh
+++ b/utils/build_all.sh
@@ -10,7 +10,7 @@ echo 'copying database related files'
 cp -R database/buildSchema ./build/database/
 cp -R database/insertData ./build/database/
 cp -R database/snapshotOptions ./build/database/
-cp -R database/basic_snapshot ./build/database/
+cp -R database/core_templates ./build/database/
 # _snapshots needs to be created manually because not in repo (.gitignore)
 mkdir ./build/database/_snapshots
 echo 'copying import/export scripts for snapshots'


### PR DESCRIPTION
Just noticed this when helping Adam -- when we changed the name to "core_templates", we forgot to update the build script.

I think there's quite possibly other things missing too, maybe?