### PR TITLE
Fix for build script

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,5 +68,5 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src", "database"],
-  "exclude": ["jest.config.js", "./plugins/*/**", "./buildScripts/*"]
+  "exclude": ["jest.config.js", "./plugins/*/**", "./buildScripts/*", "./src/modules/*"]
 }


### PR DESCRIPTION
I've excluded the whole `/modules` folder from typescript compilation (in tsconfig) as nothing in there is required for the app to run (it's pulled from packages).

This prevents the missing "testSecrets" error.