### PR TITLE
#622 Handle either type of empty row restriction (null or {})

### DIFF
--- a/src/components/outcomes/helpers.ts
+++ b/src/components/outcomes/helpers.ts
@@ -129,7 +129,10 @@ const getFilters = (
   orgId: number | undefined
 ): object => {
   // We're only interested in the highest priority restrictions
-  const restrictions = outcomes[0].rowRestrictions || { id: { isNull: false } }
+  const restrictions =
+    outcomes[0].rowRestrictions == null || Object.keys(outcomes[0].rowRestrictions).length === 0
+      ? { id: { isNull: false } }
+      : outcomes[0].rowRestrictions
   // Substitute userId/orgId placeholder with actual values
   return mapValuesDeep(restrictions, (node: any) => {
     if (typeof node !== 'string') return node


### PR DESCRIPTION
Fix #622 

For background, the filter `{ id: { isNull: false } }` is just a dummy filter that is required, or else GraphQL throws an error for "empty filter object".

Previously the logic looked for `null` in row restrictions and puts this dummy filter in if so. Now it also checks for empty object `{}` too (which is the default value for the row_restrictions field)