### PR TITLE
#1046F fix grant revoke permission actions

### DIFF
--- a/documentation/List-of-Action-plugins.md
+++ b/documentation/List-of-Action-plugins.md
@@ -1,7 +1,6 @@
 ## Contents
 
 <!-- toc -->
-
 - [Console Log](#console-log)
 - [Change Outcome](#change-outcome)
 - [Increment Stage](#increment-stage)
@@ -319,8 +318,6 @@ Grants permission to user/org -- i.e. creates `permission_join` from user/org to
 
 Revokes permissions from to user/org -- i.e. sets the `is_active` field to `false` on `permission_join` for a given user/org and permission name.
 
-`permission_join`s are never actually removed, they just get set to inactive -- this ensures that a user can still _read_ previous applications, even if they've lost permissions for that type, they just can't create new ones. _**NOTE**: This functionality not actually implemented yet in policies/front-end -- TO-DO_
-
 - _Action Code:_ **`revokePermissions`**
 
 | Input parameters<br />(\*required) <br/> | Output properties                                                                    |
@@ -329,6 +326,9 @@ Revokes permissions from to user/org -- i.e. sets the `is_active` field to `fals
 | `permissionNames`\* [Array of names]     |                                                                                      |
 | `orgName`                                |                                                                                      |
 | `orgId`                                  |                                                                                      |
+| `isRemovingPermission` (default: `true`)                                 |                                                                                      |
+
+The `isRemovingPermission` parameter specifies whether or not the `permission_join` record should be *deleted* (the default behaviour) or just set to inactive (which would mean the user can still *view* their applications but not create new ones, or submit existing). _**NOTE**: This functionality not actually implemented yet in policies/front-end, so only full removal should be used currently -- TO-DO_
 
 ---
 

--- a/plugins/action_grant_permissions/src/grantPermissions.ts
+++ b/plugins/action_grant_permissions/src/grantPermissions.ts
@@ -13,10 +13,13 @@ const grantPermissions = async ({ applicationData, parameters, DBConnect }: Acti
     const outputNames = []
 
     for (const permissionName of permissionNames) {
-      const permissionJoinId =
-        orgName || orgId // Can use either one to create a permission_join with a company
-          ? await DBConnect.joinPermissionNameToUserOrg(username, orgName || orgId, permissionName)
-          : await DBConnect.joinPermissionNameToUser(username, permissionName)
+      const permissionJoinId = Boolean(orgName || orgId) // Can use either one to create a permission_join with a company
+        ? await DBConnect.joinPermissionNameToUserOrg(
+            username,
+            orgName || Number(orgId),
+            permissionName
+          )
+        : await DBConnect.joinPermissionNameToUser(username, permissionName)
       permissionJoinIds.push(permissionJoinId)
       if (permissionJoinId) outputNames.push(permissionName)
     }

--- a/plugins/action_revoke_permissions/src/databaseMethods.ts
+++ b/plugins/action_revoke_permissions/src/databaseMethods.ts
@@ -23,10 +23,15 @@ const databaseMethods = (DBConnect: any) => ({
   revokePermissionFromUserOrg: async (
     username: string,
     org: string | number,
-    permissionNames: string[]
+    permissionNames: string[],
+    isRemovingPermissions: boolean
   ) => {
     const text = `
-      UPDATE permission_join SET is_active = false
+      ${
+        isRemovingPermissions
+          ? 'DELETE FROM permission_join '
+          : 'UPDATE permission_join SET is_active = false '
+      } 
       WHERE user_id = (
         SELECT id from "user" WHERE username = $1
       ) AND organisation_id = ${

--- a/plugins/action_revoke_permissions/src/databaseMethods.ts
+++ b/plugins/action_revoke_permissions/src/databaseMethods.ts
@@ -24,7 +24,7 @@ const databaseMethods = (DBConnect: any) => ({
     username: string,
     org: string | number,
     permissionNames: string[],
-    isRemovingPermissions: boolean
+    isRemovingPermissions: boolean = true
   ) => {
     const text = `
       ${

--- a/plugins/action_revoke_permissions/src/revokePermissions.ts
+++ b/plugins/action_revoke_permissions/src/revokePermissions.ts
@@ -6,14 +6,16 @@ const revokePermissions = async ({ applicationData, parameters, DBConnect }: Act
   const db = databaseMethods(DBConnect)
   // Don't specify orgName/Id default because we might be targeting a permission_join with no user (even if application has organisation)
   const { username = applicationData?.username, orgName, orgId, permissionNames } = parameters
+  const isRemovingPermission = true
   try {
-    const result =
-      orgName || orgId
-        ? await db.revokePermissionFromUserOrg(username, orgName || orgId, permissionNames)
-        : await db.revokePermissionFromUser(username, permissionNames)
-
-    console.log('Revoked permissions:')
-    console.log({ username, orgName, orgId, permissions: result })
+    const result = Boolean(orgName || orgId)
+      ? await db.revokePermissionFromUserOrg(
+          username,
+          orgName || Number(orgId),
+          permissionNames,
+          isRemovingPermission
+        )
+      : await db.revokePermissionFromUser(username, permissionNames)
 
     return {
       status: ActionQueueStatus.Success,

--- a/plugins/action_revoke_permissions/src/revokePermissions.ts
+++ b/plugins/action_revoke_permissions/src/revokePermissions.ts
@@ -5,8 +5,7 @@ import databaseMethods from './databaseMethods'
 const revokePermissions = async ({ applicationData, parameters, DBConnect }: ActionPluginInput) => {
   const db = databaseMethods(DBConnect)
   // Don't specify orgName/Id default because we might be targeting a permission_join with no user (even if application has organisation)
-  const { username = applicationData?.username, orgName, orgId, permissionNames } = parameters
-  const isRemovingPermission = true
+  const { username = applicationData?.username, orgName, orgId, permissionNames, isRemovingPermission = true } = parameters
   try {
     const result = Boolean(orgName || orgId)
       ? await db.revokePermissionFromUserOrg(


### PR DESCRIPTION
Use front-end PR: https://github.com/openmsupply/application-manager-web-app/pull/1059

### Changes
- Add type cast to make sure correct functions are called
- Update revokePermisison for user and org to be deleted (permission_join only) to keep this simple  

### Test
Using latest **demo_angola** snapshot called: demo_angola_2021_11_25 with the template grantUserPermissions updated 

Question: Do I add something on docs about that change on the revokePermisison action? Probably should right?
