### PR TITLE
Remove NPX from postgraphile launch

### DIFF
--- a/utils/postgraphile_launch_permissions.sh
+++ b/utils/postgraphile_launch_permissions.sh
@@ -1,3 +1,3 @@
 #TO-DO: Replace string with variable for DB name
 
-npx postgraphile -c "postgres://postgres@localhost/tmf_app_manager" -r graphile_user -C postgres --watch 
+postgraphile -c "postgres://postgres@localhost/tmf_app_manager" -r graphile_user -C postgres --watch


### PR DESCRIPTION
Just realised this was still in here, whereas the `postgraphile_launch.sh` file doesn't. Changed for consistency.