### PR TITLE
Org-only permissions

### DIFF
--- a/src/components/databaseConnect.ts
+++ b/src/components/databaseConnect.ts
@@ -108,6 +108,8 @@ class DBConnect {
 
   public getUserTemplatePermissions = PostgresDB.getUserTemplatePermissions
 
+  public getOrgTemplatePermissions = PostgresDB.getOrgTemplatePermissions
+
   public getAllPermissions = PostgresDB.getAllPermissions
 
   public getTemplatePermissions = PostgresDB.getTemplatePermissions

--- a/src/components/permissions/loginHelpers.ts
+++ b/src/components/permissions/loginHelpers.ts
@@ -59,6 +59,10 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
     orgId || null
   )
 
+  // Also get org-only permissions
+  if (orgId)
+    templatePermissionRows.push(...(await databaseConnect.getOrgTemplatePermissions(orgId)))
+
   const selectedOrg = orgId ? orgList.filter((org) => org.orgId === orgId) : undefined
 
   const returnSessionId = sessionId ?? nanoid(16)

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -653,6 +653,21 @@ class PostgresDB {
     }
   }
 
+  public getOrgTemplatePermissions = async (orgId: number) => {
+    const text = `SELECT * FROM permissions_all
+      WHERE "orgId" = $1
+      AND username IS NULL
+      `
+    const values: number[] = [orgId]
+    try {
+      const result = await this.query({ text, values })
+      return result.rows
+    } catch (err) {
+      console.log(err.message)
+      throw err
+    }
+  }
+
   public getAllPermissions = async () => {
     const text = 'select * from permissions_all'
     try {


### PR DESCRIPTION
I think this is mostly what's required for this to work. 

When fetching template permissions that go into the "userInfo" object and associated JWT, it will also fetch permissions that are associated with just the organisation and have `null` in the "user_id" field (of permission_join).

Test it by manually changing one of the entries in `permission_join` to have `null` in the user_id, and notice that it should allow access for any user belonging to that org. Should work for applicants AND reviewers (not that we'd use if for reviewers much).