### PR TITLE
generateReviewAssignments quick fix

### DIFF
--- a/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
+++ b/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.ts
@@ -29,7 +29,9 @@ async function generateReviewAssignments({
   try {
     // Get template information and current stage for application
     const { templateId, status, stageNumber, stageId, stageHistoryTimeCreated } =
-      applicationData?.applicationId ?? (await DBConnect.getApplicationData(applicationId))
+      applicationData?.applicationId
+        ? applicationData
+        : await DBConnect.getApplicationData(applicationId)
 
     // Find out which is the highest review level that has had review
     // assignments previously generated


### PR DESCRIPTION
Okay, this was something stupid I did the other day at the last minute. Used a Fallback (`??`) when I meant to use a ternary operator. 🙄

Fortunately it's easily fixed. We'll need to get this into a new build ASAP so Jess can continue working with it for her demo.