### PR TITLE
Finally! (?) fix missing FDA logo with fresh Docker-compose instance

### DIFF
--- a/docker/database.sh
+++ b/docker/database.sh
@@ -16,10 +16,6 @@ sleep 3
 
 echo '--- ADDING DATA'
 ./database/insert_data.sh $1
-# Manually copy files from core templates because the insert_data.sh script doesn't put them in the ./build folder when run from here
-# cp -r ./build/database/core_templates/files ./build
-# cp -r ./build/database/core_templates/localisation ./build
-# cp ./build/database/core_templates/preferences.json ./build
 
 echo '--- RUNNING POST INSTALL'
 ./database/turn_on_row_level_security.sh

--- a/docker/database.sh
+++ b/docker/database.sh
@@ -17,9 +17,9 @@ sleep 3
 echo '--- ADDING DATA'
 ./database/insert_data.sh $1
 # Manually copy files from core templates because the insert_data.sh script doesn't put them in the ./build folder when run from here
-cp -r ./build/database/core_templates/files ./build
-cp -r ./build/database/core_templates/localisation ./build
-cp ./build/database/core_templates/preferences.json ./build
+# cp -r ./build/database/core_templates/files ./build
+# cp -r ./build/database/core_templates/localisation ./build
+# cp ./build/database/core_templates/preferences.json ./build
 
 echo '--- RUNNING POST INSTALL'
 ./database/turn_on_row_level_security.sh

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
-if [[ ! -f /var/lib/postgresql/12/main/PG_VERSION ]]
-then
+if [[ ! -f /var/lib/postgresql/12/main/PG_VERSION ]]; then
    echo '---'
    echo 'copying fresh db to new mounted volume'
    echo '---'
    cp -r ./fresh_db/* /var/lib/postgresql/12/main
    chown -R postgres:postgres /var/lib/postgresql/12/*
    chmod -R 0700 /var/lib/postgresql/12/*
+fi
+
+if [[ ! -f ./build/files ]]; then
+   echo '---'
+   echo 'no files present, will pull from core-templates'
+   echo '---'
+   cp -r ./build/database/core_templates/files ./build
+   cp -r ./build/database/core_templates/localisation ./build
+   cp ./build/database/core_templates/preferences.json ./build
 fi
 
 echo '---'

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,7 @@ require('dotenv').config()
 const startServer = async () => {
   await loadActionPlugins() // Connects to Database and listens for Triggers
 
-  // createFilesFolder()
+  createFilesFolder()
 
   const server = fastify()
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,7 @@ require('dotenv').config()
 const startServer = async () => {
   await loadActionPlugins() // Connects to Database and listens for Triggers
 
-  createFilesFolder()
+  // createFilesFolder()
 
   const server = fastify()
 


### PR DESCRIPTION
@andreievg  showed me what I needed to do to finally fix this properly and have it work with docker-compose.

Same fix as before, but now it happens in the "entry" script rather than the setting up "database.sh" script, which gets overwritten once the docker-compose volume is attached.

Testing and working with docker-compose (with fresh database reset) on instance 50006.