### PR TITLE
Outcomes -- allow org-only permissions

### DIFF
--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -725,11 +725,13 @@ class PostgresDB {
   }
 
   public getUserOrgPermissionNames = async (userId: number, orgId: number | null | undefined) => {
+    // Only consider userId = NULL when orgId is present (can't both be NULL)
+    const userMatch = `("userId" = $1 ${orgId ? 'OR "userId" IS NULL' : ''})`
     const orgMatch = `"orgId" ${orgId ? '= $2' : 'IS NULL'}`
     const text = `
       SELECT "permissionNameId" as id,
       "permissionName" FROM permissions_all
-      WHERE "userId" = $1
+      WHERE ${userMatch}
       AND ${orgMatch}`
     const values: number[] = [userId]
     if (orgId) values.push(orgId)


### PR DESCRIPTION
Based on chat with @jagoje on Telegram:
<img width="600" alt="Screen Shot 2021-12-16 at 2 32 22 PM" src="https://user-images.githubusercontent.com/5456533/146291492-13dae4a0-91ce-4c38-905e-3d37bf67c92c.png">

I realised that it wouldn't work with org-only permissions without a small tweak to the `getUserOrgPermissionNames` query to also consider `userId IS NULL` permission joins.