### PR TITLE
#664 Fix user permissions endpoint

### DIFF
--- a/documentation/API.md
+++ b/documentation/API.md
@@ -201,7 +201,8 @@ The same as login endpoint, without the success field
 GET: `/user-permissions?username=<username>&orgId=<orgId>`
 
 End point to get **another** user's granted permissions + all existing permissions on templates for a given organisation.
-Intended for use in template to view/edit antoher user's permissions -- client supplies `username` and `orgId`.
+Intended for use in template to view/edit another user's permissions -- client supplies `username` and `orgId`.
+Either `username` or `orgId` can be omitted and the result will returned for that user without an org, or for that org without a user. For `orgId`, the values `null` or `0` are equivalent to omitting `orgId` and for `username` an empty string `""` can be used. This is useful in cases such as a template query where you're supplying an `orgId` and `username` parameter, but can't "turn off" the parameters when you want to omit either of them -- just use `orgId=null` or `username=""` to achieve the same thing.
 
 #### Check Triggers
 

--- a/documentation/API.md
+++ b/documentation/API.md
@@ -200,9 +200,13 @@ The same as login endpoint, without the success field
 
 GET: `/user-permissions?username=<username>&orgId=<orgId>`
 
-End point to get **another** user's granted permissions + all existing permissions on templates for a given organisation.
-Intended for use in template to view/edit another user's permissions -- client supplies `username` and `orgId`.
-Either `username` or `orgId` can be omitted and the result will returned for that user without an org, or for that org without a user. For `orgId`, the values `null` or `0` are equivalent to omitting `orgId` and for `username` an empty string `""` can be used. This is useful in cases such as a template query where you're supplying an `orgId` and `username` parameter, but can't "turn off" the parameters when you want to omit either of them -- just use `orgId=null` or `username=""` to achieve the same thing.
+End point to get **another** user's granted permissions + all existing permissions on templates for a given organisation. Intended for use in template to view/edit another user's permissions -- client supplies `username` and `orgId`.
+
+Either `username` or `orgId` can be omitted and the result returned will be either: 
+  * for that user without an org; or 
+  * for that org without a user. 
+  
+For `orgId`, the values `null` or `0` are equivalent to omitting `orgId` and for `username` an empty string `""` can be used. This is useful in cases such as a template query where you're supplying an `orgId` and `username` parameter, but can't "turn off" the parameters when you want to omit either of them -- just use `orgId=null` or `username=""` to achieve the same thing.
 
 #### Check Triggers
 

--- a/src/components/permissions/loginHelpers.ts
+++ b/src/components/permissions/loginHelpers.ts
@@ -56,7 +56,8 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
 
   const templatePermissionRows = await databaseConnect.getUserTemplatePermissions(
     newUsername,
-    orgId || null
+    orgId || null,
+    true
   )
 
   // Also get org-only permissions

--- a/src/components/permissions/routes.ts
+++ b/src/components/permissions/routes.ts
@@ -92,12 +92,17 @@ const routeUserPermissions = async (request: any, reply: any) => {
       message: 'Missing username or orgId in query.',
     })
 
-  const { username } = query
-  const orgId = query?.orgId ?? null
+  const username = query?.username === '' ? null : query?.username ?? null
+  const orgId: number | null =
+    query?.orgId === 'null' || query?.orgId === '0'
+      ? null
+      : query?.orgId
+      ? Number(query.orgId)
+      : null
 
   if (auth.error) return reply.send({ success: false, message: auth.console.error })
 
-  const isSystemOrg = await databaseConnect.isInternalOrg(Number(orgId))
+  const isSystemOrg = orgId ? await databaseConnect.isInternalOrg(orgId) : false
 
   const templatePermissionRows = await databaseConnect.getTemplatePermissions(isSystemOrg)
 

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -654,12 +654,19 @@ class PostgresDB {
     }
   }
 
-  public getUserTemplatePermissions = async (username: string, orgId: number | null) => {
+  public getUserTemplatePermissions = async (
+    username: string,
+    orgId: number | null,
+    includeUserCategory = false
+  ) => {
     const orgMatch = `"orgId" ${orgId === null ? 'IS NULL' : '= $2'}`
+
+    // "User" category permissions are ONLY included in login routes
+    const userCategoryString = includeUserCategory ? ` OR "isUserCategory" = true` : ''
 
     const text = `SELECT * FROM permissions_all
       WHERE username = $1
-      AND (${orgMatch} OR "isUserCategory" = true)
+      AND (${orgMatch}${userCategoryString})
       `
 
     const values: (string | number)[] = [username]


### PR DESCRIPTION
Fix #664 

A bit of a subtle change here, but makes a big difference in how the "grantPermissions" template works.

- Firstly, the `OR "isUserCategory" = true` clause in "getTemplatePermissions" was giving false data when used in this endpoint (although it was doing the expected thing when used in the /login endpoints). It was always returning that whatever permission name is associated with the "User" category is granted to the user/org even when it wasn't. I've added an additional parameter to "getTemplatePermissions" which allows turning this on or off -- it's only useful in the login context.
- Better handling of null/undefined values for username or orgId. These parameters can either be omitted, or accept `orgId=null` / `orgId=0` and `username=""` as the same thing. Useful for the grantPermissions template when we need to conditionally supply these values, but can't turn the parameters "off" completely.