### PR TITLE
#488 #908F Evaluator array access

### DIFF
--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -95,7 +95,7 @@ This expression would return the number **8** when evaluated. If `children` are 
 
 ## type
 
-The `type` property is optional in most cases, but some operators will return their results in a different format depending on the `type` (e.g. pgSQL -- see below). For *all* operators, the output will also be attempted to convert it to to the specified `type`. This can be useful, for example, when a number is required from a string output. Note: type conversion follows Javascript type conversion rules using `Number(), String(), Boolean()`.
+The `type` property is optional in most cases, but some operators will return their results in a different format depending on the `type` (e.g. pgSQL -- see below). For *all* operators, the evaluator will also attempt to convert it to to the specified `type`. This can be useful, for example, when a number is required from a string output. Note: type conversion follows Javascript type conversion rules using `Number(), String(), Boolean()`.
 
 Valid values:
 

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -485,7 +485,7 @@ i.e `{user: "user"}`
 
 Tree structure:
 
-[[images/query-syntax-example-1.png|Example 1 tree diagram]]
+![Example 1 tree diagram](images/query-syntax-example-1.png)
 
 ```
 {
@@ -511,7 +511,7 @@ _Note: this query uses PostGres (pgSQL) operator -- in the app, we’ll probably
 
 Tree structure:
 
-[[images/query-syntax-example-2.png|Example 2 tree diagram]]
+![Example 2 tree diagram](images/query-syntax-example-2.png)
 
 ```
 {
@@ -552,7 +552,7 @@ Tree structure:
 
 Tree structure:
 
-[[images/query-syntax-example-3b.png|Example 3 tree diagram]]
+![Example 3 tree diagram](images/query-syntax-example-3b.png)
 
 ```
 {
@@ -705,7 +705,7 @@ Then you can bump the minimum version of the package in the dependent projects (
 
 This is a browser-based dev tool within the expression-evaluator folder (`/expression-evaluate-gui`) to make building complex queries for templates easy to test and debug.
 
-[[images/query-syntax-gui_screenshot.png|GUI screenshot]]
+![GUI screenshot](images/query-syntax-gui_screenshot.png)
 
 As it's a stand-alone project, before using it you'll need to run `yarn install` from within
 the **expression-evaluate-gui** folder

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -101,7 +101,7 @@ Valid values:
 
 - string
 - number
-- boolean
+- boolean / bool
 - array
 
 # Operators

--- a/documentation/Query-Syntax.md
+++ b/documentation/Query-Syntax.md
@@ -59,7 +59,6 @@ For more complex lookups, we would hide the complexity from the user in the Temp
     - [`expression`](#expression)
     - [`parameters`](#parameters)
 - [Examples](#examples)
-- [To Do](#to-do)
 - [Installation](#installation)
 - [Testing](#testing)
 - [Development](#development)
@@ -96,7 +95,7 @@ This expression would return the number **8** when evaluated. If `children` are 
 
 ## type
 
-The `type` property is optional in most cases, but some operators will return their results in a different format depending on the `type` (e.g. pgSQL -- see below).
+The `type` property is optional in most cases, but some operators will return their results in a different format depending on the `type` (e.g. pgSQL -- see below). For *all* operators, the output will also be attempted to convert it to to the specified `type`. This can be useful, for example, when a number is required from a string output. Note: type conversion follows Javascript type conversion rules using `Number(), String(), Boolean()`.
 
 Valid values:
 
@@ -104,7 +103,6 @@ Valid values:
 - number
 - boolean
 - array
-- object (maybe? -- not required yet)
 
 # Operators
 
@@ -181,7 +179,7 @@ The `evaluateExpression` function expects each expression to be passed along wit
 
 - Input:
 
-  - 1st child node returns the name of the field whose value is to be extracted. Can be a nested property, written in dot notation (e.g. `questions.q2`) (but cannot yet get specific elements from arrays.)
+  - 1st child node returns the name of the field whose value is to be extracted. Can be a nested property, written in dot notation (e.g. `questions.q2`)
   - 2nd (optional) node returns a Fallback value, to be returned if the property specified in the first node can't be resolved. Default is string "Can't resolve object", but could be useful to set to `null` in some cases.
 
 - Output: the value specified in `property` of any type.
@@ -207,6 +205,19 @@ application = {
   stage: 1,
   responses: { q1: 'What is the answer?', q2: 'Enter your name' },
 }
+```
+
+**Note**: arrays can be accessed in multiple ways, depending on your requirements. Most simply, arrays can be accessed by index, e.g. `responses.user.selection[1]`. However, if there is an array of objects, it's possible to return a single property from within each object as an array. For example, if you have data object:
+```
+{ orgs: [{id: 1, name: "Org 1"}, {id: 2, name: "Org 2"}]}
+```
+The following property strings will return these results:
+```
+"orgs" -> [{id: 1, name: "Org 1"}, {id: 2, name: "Org 2"}]
+"orgs.name" -> [ "Org 1", "Org 2" ]
+"orgs[0]" -> {id: 1, name: "Org 1"}
+"orgs[1].id" -> 2
+
 ```
 
 ## stringSubstitution
@@ -267,7 +278,7 @@ Performs queries on connected GraphQL interface.
   - 2nd child node returns a **string** containing the url of the GrapqhQL endpoint. Using the value "graphQLEndpoint" (or empty string `""`) will the use the graphQL endpoint specified in the input parameter "GraphQLConnection" object.
   - 3nd child node returns an **array** of field names for the query's associated variables object. If no variables are required for the query, pass an empty array (i.e. `{ value: [] }`).
   - 4rd...N-1 child nodes return the values of the fields for the variables object -- one node for each field in the previous node's array.
-  - The Nth (last) child node returns a **string** stating the node in the returned GraphQL object that is required. E.g. `applications.name` Because GraphQL returns results as nested objects, to get an output in a "simple type", a node in the return object tree is needed. (See examples below and in `TestData`). This last node is optional -- if not provided, the whole result object will be returned unmodified.
+  - The Nth (last) child node returns a **string** stating the node in the returned GraphQL object that is required. E.g. `applications.name` Because GraphQL returns results as nested objects, to get an output in a "simple type", a node in the return object tree is needed. (See examples below and in `TestData`). This last node is optional -- if not provided, the whole result object will be returned unmodified. This extraction follows the same rules as "[objectProperties](#objectproperties) operator above.
 - Output: the returned GraphQL node can be either `string`, `number`, `boolean`, `array`, or `object`. If the output is an object, it will be returned as follows:
 
   - If there is only one field, only the value of the field will be returned.
@@ -347,7 +358,7 @@ This expression queries our `/login` endpoint to check a user's credentials, and
 
 ### Authentication
 
-The `GET`, `POST`, and `GraphQL` operators may require authentication for the endpoints they are querying, such as our own [API](API.md). This can be achieved in a couple of different ways.
+The `GET`, `POST`, and `GraphQL` operators may require authentication for the endpoints they are querying, such as our own [API](API). This can be achieved in a couple of different ways.
 
 1. Pass the authentication information as part of the [parameters](#parameters) `headers` field. For example, a JWT authentication might be:  
     ```
@@ -474,7 +485,7 @@ i.e `{user: "user"}`
 
 Tree structure:
 
-![Example 1 tree diagram](images/query-syntax-example-1.png)
+[[images/query-syntax-example-1.png|Example 1 tree diagram]]
 
 ```
 {
@@ -500,7 +511,7 @@ _Note: this query uses PostGres (pgSQL) operator -- in the app, we’ll probably
 
 Tree structure:
 
-![Example 2 tree diagram](images/query-syntax-example-2.png)
+[[images/query-syntax-example-2.png|Example 2 tree diagram]]
 
 ```
 {
@@ -541,7 +552,7 @@ Tree structure:
 
 Tree structure:
 
-![Example 3 tree diagram](images/query-syntax-example-3b.png)
+[[images/query-syntax-example-3b.png|Example 3 tree diagram]]
 
 ```
 {
@@ -578,7 +589,7 @@ Tree structure:
 
 Tree structure:
 
-![Example 3 tree diagram](images/query-syntax-example-3.png)
+[[images/query-syntax-example-3.png|Example 3 tree diagram]]
 
 ```
 {
@@ -616,15 +627,6 @@ Tree structure:
 ```
 
 -->
-
-# To Do
-
-- ~~Convert to typescript.~~
-- ~~Make function async and all operators return Promises (currently only pgSQL does, which is not very consistent)~~
-- ~~Better error handling~~
-- Create mocks (or alt?) for Database queries in jest test suite
-- ~~Figure out how to make into a module that can be easily imported into both front-end and back-end repositories.~~
-- Pass JWT/auth token to database operators
 
 <a name="installation"></a>
 
@@ -670,7 +672,7 @@ There is a [Jest](https://jestjs.io/) test suite for the expression evaluator in
 
 However, for the tests to work you'll need two things:
 
-1. Load the [snapshot](Snapshots.md) called `evaluator_test` from the private templates repo (in `/dev/snapshots`)
+1. Load the [snapshot](Snapshots) called `evaluator_test` from the private templates repo (in `/dev/snapshots`)
 2. You'll need to provide authentication JWTs for certain tests. The test suite is expecting a file called `testSecrets.json` in the evaluator /src folder, with the following info:  
 ```
 {
@@ -703,7 +705,7 @@ Then you can bump the minimum version of the package in the dependent projects (
 
 This is a browser-based dev tool within the expression-evaluator folder (`/expression-evaluate-gui`) to make building complex queries for templates easy to test and debug.
 
-![GUI screenshot](images/query-syntax-gui_screenshot.png)
+[[images/query-syntax-gui_screenshot.png|GUI screenshot]]
 
 As it's a stand-alone project, before using it you'll need to run `yarn install` from within
 the **expression-evaluate-gui** folder

--- a/src/modules/expression-evaluator/package.json
+++ b/src/modules/expression-evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmsupply/expression-evaluator",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "description": "Module to evaluate dynamic expressions for the openMsupply Application Manager project",
   "main": "lib/evaluateExpression.js",
   "types": "lib/evaluateExpression.d.ts",

--- a/src/modules/expression-evaluator/src/evaluateExpression.test.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpression.test.ts
@@ -802,6 +802,100 @@ test('Object functions -- generate a date from two strings', () => {
   })
 })
 
+// Type conversion
+test('Extract numbers from array', () => {
+  return evaluateExpression(
+    {
+      operator: 'objectProperties',
+      type: 'number',
+      children: ['responses.orgs.id'],
+    },
+    {
+      objects: { responses: testData.responses },
+    }
+  ).then((result: any) => {
+    expect(result).toBe(628)
+  })
+})
+
+test('Join array into single string', () => {
+  return evaluateExpression(testData.listOfOrgs, {
+    graphQLConnection: {
+      fetch: fetch,
+      endpoint: graphQLendpoint,
+    },
+  }).then((result: any) => {
+    expect(result).toBe(
+      'Food & Drug Agency,Pharma123,Manufacturer Medical,National Medical,Holistic Medicine AU,Bayer (Pty) Ltd,Novartis Spain,Fine Chemicals Corp (Pty) Ltd,Pharma Suppliers,Regional Pharm First,Pharmed Corp Ltd Pty,Global Health Incorporated,Adam Company 2'
+    )
+  })
+})
+
+test('Coerce string to boolean', () => {
+  return evaluateExpression({
+    operator: '=',
+    children: [
+      {
+        operator: '+',
+        type: 'bool',
+        children: ['three'],
+      },
+      true,
+    ],
+  }).then((result: any) => {
+    expect(result).toBe(true)
+  })
+})
+
+// Access array by index
+test('Return index from array', () => {
+  return evaluateExpression(
+    {
+      operator: 'objectProperties',
+      children: ['responses.user.selection[1]'],
+    },
+    {
+      objects: { responses: testData.responses },
+    }
+  ).then((result: any) => {
+    expect(result).toEqual({
+      id: 9,
+      email: 'noreply@sussol.net',
+      lastName: 'Madruga',
+      username: 'nicole',
+      firstName: 'Nicole',
+    })
+  })
+})
+
+test('Return index -- middle of string', () => {
+  return evaluateExpression(
+    {
+      operator: 'objectProperties',
+      children: ['responses.user.selection[0].username'],
+    },
+    {
+      objects: { responses: testData.responses },
+    }
+  ).then((result: any) => {
+    expect(result).toEqual('carl')
+  })
+})
+
+test('Try and access non-indexable object', () => {
+  return evaluateExpression(
+    {
+      operator: 'objectProperties',
+      children: ['responses.user[2]'],
+    },
+    {
+      objects: { responses: testData.responses },
+    }
+  ).then((result: any) => {
+    expect(result).toEqual('Object not index-able')
+  })
+})
+
 // TO-DO: Write some tests for showing error conditions
 
 afterAll(() => {

--- a/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
+++ b/src/modules/expression-evaluator/src/evaluateExpressionTestData.ts
@@ -1216,3 +1216,63 @@ testData.obFunc2 = {
   operator: 'objectFunctions',
   children: ['functions.fDate', { operator: '+', children: ['December 17, ', '1995 03:24:00'] }],
 }
+
+// Type conversion
+testData.responses = {
+  user: {
+    id: 629,
+    timeUpdated: '2022-02-24T10:24:30.548061+13:00',
+    text: '{email: carl@sussol.net, firstName: Carl, id: 8, lastName: Smith, username: carl}',
+    selection: [
+      {
+        id: 8,
+        email: 'noreply@sussol.net',
+        lastName: 'Smith',
+        username: 'carl',
+        firstName: 'Carl',
+      },
+      {
+        id: 9,
+        email: 'noreply@sussol.net',
+        lastName: 'Madruga',
+        username: 'nicole',
+        firstName: 'Nicole',
+      },
+    ],
+  },
+  orgs: [
+    {
+      id: 628,
+      name: 'Royal Inc.',
+    },
+  ],
+  currentUser: {
+    userId: 2,
+    username: 'admin',
+    firstName: 'Admin',
+    lastName: 'Admin',
+    email: null,
+    dateOfBirth: null,
+    organisation: {
+      orgId: 1,
+      orgName: 'PNG Demo Authority',
+      userRole: 'Owner',
+      registration: 'fda',
+      address: null,
+      logoUrl: '/file?uid=NPQ4Wo_mUS1KSnuSUyIXS',
+      isSystemOrg: true,
+    },
+    sessionId: 'GlGHjaesRA82g1sJ',
+  },
+}
+
+testData.listOfOrgs = {
+  operator: 'graphQL',
+  type: 'string',
+  children: [
+    'query getOrgs {organisations { nodes {id, name}}}',
+    '',
+    [],
+    'organisations.nodes.name',
+  ],
+}


### PR DESCRIPTION
Fix #488 (and front-end [#908](https://github.com/openmsupply/application-manager-web-app/issues/908))

Finally got round to adding this. Arrays can now be access via index, and output types can be coerced into other types. Will make certain queries a bit less hassle in templates.

All previous behaviour is preserved, and I've updated the docs to explain a bit more detail.

Have added a few new tests to check the new behaviour. All previous tests still pass.