### PR TITLE
#668 modifyRecord improvements & #1125F

### DIFF
--- a/plugins/action_modify_record/src/modifyRecord.ts
+++ b/plugins/action_modify_record/src/modifyRecord.ts
@@ -77,9 +77,35 @@ const getPostgresType = (value: any): string => {
     const elementType = value.length > 0 ? getPostgresType(value[0]) : 'varchar'
     return `${elementType}[]`
   }
-  if (value instanceof Date) return 'timestamptz'
+  if (isDateString(value)) return 'date'
+  if (isTimeString(value)) return 'time with timezone'
+  if (isDateTimeString(value)) return 'timestamptz'
   if (value instanceof Object) return 'jsonb'
   if (typeof value === 'boolean') return 'boolean'
   if (typeof value === 'number') return Number.isInteger(value) ? 'integer' : 'double precision'
   return 'varchar'
+}
+
+const isDateString = (value: any) => {
+  // This is the date format (ISO Date) stored in DatePicker responses
+  if (typeof value !== 'string') return false
+  const datePattern = /^\d{4}-(0\d|1[0-2])-([0-2]\d|3[0-1])$/
+  return datePattern.test(value)
+}
+
+// We don't yet have plugins that store time or dateTime responses, so these
+// won't really be used yet. Added for completeness.
+
+const isTimeString = (value: any) => {
+  if (typeof value !== 'string') return false
+  const timePattern =
+    /^(0\d|1\d|2\d):([0-5]\d):([0-5]\d)(\.\d{1,6})?([\+,-](0\d|1\d|2\d)(:([0-5]\d))?)?$/
+  return timePattern.test(value)
+}
+
+const isDateTimeString = (value: any) => {
+  if (typeof value !== 'string') return false
+  const dateTimePattern =
+    /^\d{4}-(0\d|1[0-2])-([0-2]\d|3[0-1]) (0\d|1\d|2\d):([0-5]\d):([0-5]\d)(\.\d{1,6})?([\+,-](0\d|1\d|2\d)(:([0-5]\d))?)?$/
+  return dateTimePattern.test(value)
 }


### PR DESCRIPTION
Fix #668

Also solves the issue raised by [front-end #1125](https://github.com/openmsupply/application-manager-web-app/issues/1125) -- we don't need to make changes to that plugin, the problem was that ISO dates weren't being interpreted as postgres "date" types, so I've fixed that here.

Basically, it'll be much easier to fill in "modifyRecord" actions in the template builder now -- instead of painstakingly filling out a dozen (or more!) separate parameters, each with their own evaluator expression to fetch data from form responses, we can now do it all in one with a simple mapping from form responses to data record values. (See docs and original issue for more details)

Easiest way to test is to use the `/run-action` endpoint, with something like this as the body JSON:
```
{
    "actionCode": "modifyRecord",
    "applicationId": 19,
    "parameters": {
        "tableName": "test",
        "start_date": "2022-01-23",
        "company_id" : 4,
        "license_type": {"three": 3},
        "data": {
            "first_name": "responses.Q1.text",
            "last_name": "responses.Q2.text",
            "type": "responses.Q5",
            "new_date": "responses.date.date.start"
        },
        "shouldCreateJoinTable": false
    } 
}
```
Change the "applicationID" and the "responses..." values to match an application you're working with. When run, a record will be created in a new "test" table with all the above fields, and the ones in the "data" object pulled straight from application responses.

Also note the data types are now correct for dates, as long as they are in one of the standard ISO formats (such as "start_date" above -- a postGres "date" field will be created)

