### PR TITLE
#696 add description to user permissions endpoint

### DIFF
--- a/database/buildSchema/15_template_permission.sql
+++ b/database/buildSchema/15_template_permission.sql
@@ -17,6 +17,7 @@ CREATE VIEW permissions_all AS (
         organisation.name AS "orgName",
         "template".code AS "templateCode",
         permission_name.name AS "permissionName",
+        permission_name.description AS "description",
         template_permission.stage_number AS "stageNumber",
         template_permission.level_number AS "reviewLevel",
         template_permission.allowed_sections AS "allowedSections",

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -34,6 +34,8 @@ const migrateData = async () => {
   if (databaseVersionLessThan('0.1.0')) {
     console.log('Migrating to 0.1.0...')
     // Create "system_info" table
+    console.log(' - Add system_info TABLE');
+    
     await DB.changeSchema(`
       CREATE TABLE public.system_info (
         id serial PRIMARY KEY,
@@ -42,6 +44,7 @@ const migrateData = async () => {
         timestamp timestamptz DEFAULT CURRENT_TIMESTAMP
       );
     `)
+    console.log('Done migrating on v0.1.0...');
   }
 
   // v0.2.0
@@ -49,15 +52,19 @@ const migrateData = async () => {
     console.log('Migrating to v0.2.0...')
 
     // Add "assigned_sections" column to schema
+    console.log(' - Add review_assignment TABLE field: assigned_sections');
+    
     await DB.changeSchema(`ALTER TABLE review_assignment
         ADD COLUMN assigned_sections varchar[] DEFAULT array[]::varchar[];`)
 
     // Update or create review_assignment assigned_sections Trigger/Function
+    console.log(' - Add review_assignment_trigger2 TRIGGER field: assigned_sections');
     await DB.changeSchema(
       'DROP TRIGGER IF EXISTS review_assignment_trigger2 ON public.review_assignment'
     ) // CREATE OR REPLACE not working
     await DB.changeSchema('DROP FUNCTION unassign_review_without_sections')
 
+    console.log(' - Update empty_assigned_sections FUNCTION: count using assigned_sections');
     await DB.changeSchema(`CREATE OR REPLACE FUNCTION public.empty_assigned_sections () RETURNS TRIGGER AS $review_assignment_event$
         BEGIN
             UPDATE public.review_assignment SET assigned_sections = '{}'
@@ -67,12 +74,15 @@ const migrateData = async () => {
         $review_assignment_event$
         LANGUAGE plpgsql;`)
 
+    console.log(' - Update review_assignment_trigger2 TRIGGER: set empty assigned_sections based on status');
+        
     await DB.changeSchema(`CREATE TRIGGER review_assignment_trigger2
     AFTER UPDATE OF status ON public.review_assignment
     FOR EACH ROW WHEN (NEW.status = 'AVAILABLE')
     EXECUTE FUNCTION public.empty_assigned_sections ();`)
 
     // Update function to count assigned questions
+    console.log(' - Update assigned_questions_count FUNCTION: count using assigned_sections');
     await DB.changeSchema(`CREATE OR REPLACE FUNCTION public.assigned_questions_count (app_id int, stage_id int, level int)
     RETURNS bigint
     AS $$
@@ -103,6 +113,8 @@ const migrateData = async () => {
     LANGUAGE sql
     STABLE;`)
 
+    console.log(' - Update submitted_assigned_questions_count FUNCTION: count using assigned_sections');
+    
     await DB.changeSchema(`CREATE OR REPLACE FUNCTION public.submitted_assigned_questions_count (app_id int, stage_id int, level_number int) RETURNS bigint AS $$
     SELECT COUNT(DISTINCT (te.id))
     FROM (SELECT id, application_id, stage_id, level_number, status,
@@ -129,6 +141,8 @@ const migrateData = async () => {
     STABLE;`)
 
     // Create missing "assigned sections" for existing review_assignments
+    console.log(' - Update field in review_assignments TABLE: assigned_sections');
+    
     try {
       const reviewAssignments = await DB.getIncompleteReviewAssignments()
       const reviewAssignmentsWithSections: ReviewAssignmentsWithSections = {}
@@ -154,10 +168,15 @@ const migrateData = async () => {
     }
 
     // DROP review_question_assignment and related views/fields
+    console.log(' - Remove column in review_reponse TABLE: review_question_assignment_id');
     await DB.changeSchema(`ALTER TABLE review_response
         DROP COLUMN review_question_assignment_id;`)
+
+    console.log(' - Remove review_question_assignment_section VIEW');
     await DB.changeSchema(`DROP VIEW IF EXISTS
       public.review_question_assignment_section;`)
+
+    console.log(' - Remove review_question_assignment TABLE and linked records...');
     await DB.changeSchema(`DROP TABLE IF EXISTS
       public.review_question_assignment CASCADE;`)
 
@@ -167,6 +186,7 @@ const migrateData = async () => {
     )
 
     // Update function to generate template_element_id for review_response
+    console.log(' - Update set_original_response FUNCTION generated field: template_element_id (from review_response)');
     await DB.changeSchema(
       `CREATE OR REPLACE FUNCTION set_original_response () RETURNS TRIGGER AS $$ BEGIN IF NEW.review_response_link_id IS NOT NULL THEN NEW.original_review_response_id = (
         SELECT original_review_response_id 
@@ -186,10 +206,56 @@ const migrateData = async () => {
       RETURN NEW; END;
       $$ LANGUAGE plpgsql;`
     )
+  
+  // New field description returned in permissions_all
+  console.log(' - Add permission_all VIEW field: description');
+  
+  await DB.changeSchema(`CREATE OR UPDATE VIEW permissions_all AS (
+    SELECT
+        "user".username AS "username",
+        organisation.name AS "orgName",
+        "template".code AS "templateCode",
+        permission_name.name AS "permissionName",
+        permission_name.description AS "description",
+        template_permission.stage_number AS "stageNumber",
+        template_permission.level_number AS "reviewLevel",
+        template_permission.allowed_sections AS "allowedSections",
+        template_permission.can_self_assign AS "canSelfAssign",
+        template_permission.can_make_final_decision AS "canMakeFinalDecision",
+        template_permission.restrictions AS "restrictions",
+        permission_policy.name AS "policyName",
+        permission_policy.type AS "permissionType",
+        permission_policy.is_admin AS "isAdmin",
+        permission_policy.id AS "permissionPolicyId",
+        permission_policy.rules AS "permissionPolicyRules",
+        permission_name.id AS "permissionNameId",
+        template_permission.id AS "templatePermissionId",
+        "template".id AS "templateId",
+        "user".id AS "userId",
+        permission_join.id AS "permissionJoinId",
+        permission_join.organisation_id AS "orgId",
+        CASE WHEN template_category.ui_location @> (ARRAY['USER']::public.ui_location[]) THEN
+            TRUE
+        ELSE
+            FALSE
+        END AS "isUserCategory",
+        permission_name.is_system_org_permission AS "isSystemOrgPermission",
+        permission_join.is_active AS "isActive"
+    FROM
+        permission_name
+        JOIN permission_join ON permission_join.permission_name_id = permission_name.id
+        JOIN permission_policy ON permission_policy.id = permission_name.permission_policy_id
+        LEFT JOIN "user" ON permission_join.user_id = "user".id
+        LEFT JOIN organisation ON permission_join.organisation_id = organisation.id
+        LEFT JOIN template_permission ON template_permission.permission_name_id = permission_name.id
+        LEFT JOIN "template" ON "template".id = template_permission.template_id
+        LEFT JOIN template_category ON "template".template_category_id = template_category.id);`)
+
+    console.log('Done migrating on v0.2.0...');
   }
 
   // Other version migrations continue here...
-
+        
   // Finally, set the database version to the current version
   if (databaseVersionLessThan(version)) await DB.setDatabaseVersion(version)
 }


### PR DESCRIPTION
Fixes #696 

Required to display the `description` (translated to portuguese) instead of the name on the CreateIntUser template