### PR TITLE
730 Fix default document icons

### DIFF
--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -130,6 +130,7 @@ const useSnapshot: SnapshotOperation = async ({
       console.log('enable row level policies ... done')
     }
 
+    // To ensure generic thumbnails are not wiped out, even if server doesn't restart
     createDefaultDataFolders()
 
     return { success: true, message: `snapshot loaded ${snapshotName}` }

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -130,6 +130,8 @@ const useSnapshot: SnapshotOperation = async ({
       console.log('enable row level policies ... done')
     }
 
+    createDefaultDataFolders()
+
     return { success: true, message: `snapshot loaded ${snapshotName}` }
   } catch (e) {
     return { success: false, message: 'error while loading snapshot', error: e.toString() }


### PR DESCRIPTION
Fix #730 

I think this should address all potential cases when the default icons are not showing up. When we load a snapshot using the command line `database_init`, etc. the server automatically restarts and `createDefaultDataFolders` gets run. But when loading a snapshot on a running instance using the web UI, this doesn't happen. So I've just added a single call to `createDefaultDataFolders` after loading the snapshot to ensure that the generic thumbnails get recreated no matter what.