### PR TITLE
#732 Fix Date input for modifyRecord

### DIFF
--- a/plugins/action_modify_record/src/modifyRecord.ts
+++ b/plugins/action_modify_record/src/modifyRecord.ts
@@ -87,6 +87,7 @@ const createOrUpdateTable = async (
 export default modifyRecord
 
 const getPostgresType = (value: any): string => {
+  if (value instanceof Date) return 'timestamptz'
   if (Array.isArray(value)) {
     const elementType = value.length > 0 ? getPostgresType(value[0]) : 'varchar'
     return `${elementType}[]`


### PR DESCRIPTION
Fix #732 

I realise the type detection function didn't actually handle JS `Date` objects themselves, I'd only written matchers for ISO date and time strings. So good to fix this.

You can test it with the Angola product registration template (the "registration date" field), but a quicker test is to load this snapshot from the templates repo: `/dev/snapshots/[TEMP]_732_data_type_fix` 

Trigger the `DEV_TEST` trigger on the application with ID = 97 -- the product table will be created with correct "expiry_date" and "registration_date" fields as `timestamptz` types.