### PR TITLE
FE 1162 Row level policies to handle empty string for integer jwt claim values

### DIFF
--- a/src/components/permissions/rowLevelPolicyHelpers.ts
+++ b/src/components/permissions/rowLevelPolicyHelpers.ts
@@ -206,8 +206,8 @@ const replacePlaceholders = (sql: string, permissionAbbreviation: string) => {
   const replacements = [
     {
       prefix: 'jwtUserDetails_bigint_',
-      prefixReplacement: `COALESCE(current_setting('jwt.claims.`,
-      postfix: `', true),'0')::integer`,
+      prefixReplacement: `COALESCE(nullif(current_setting('jwt.claims.`,
+      postfix: `', true),''),'0')::integer`,
     },
     {
       prefix: 'jwtUserDetails_text_',
@@ -216,8 +216,8 @@ const replacePlaceholders = (sql: string, permissionAbbreviation: string) => {
     },
     {
       prefix: 'jwtPermission_bigint_',
-      prefixReplacement: `COALESCE(current_setting('jwt.claims.${permissionAbbreviation}_`,
-      postfix: `', true),'0')::integer`,
+      prefixReplacement: `COALESCE(nullif(current_setting('jwt.claims.${permissionAbbreviation}_`,
+      postfix: `', true),''),'0')::integer`,
     },
     {
       prefix: 'jwtPermission_array_bigint_',


### PR DESCRIPTION
closes f/e [#1162](https://github.com/openmsupply/application-manager-web-app/issues/1162)

What was happening ?

When app is used concurrently, jwt claims set as local variable for postgres transaction are not cleared to null, but to empty string, and when row level permission policies access those values coalesce doesn't capture the empty string use case and fails casting empty string to integer. After some time the claims are cleared that's why problem was hard to figure out.

Replicate in dev environment:
* run all with pg_permissions
* have two tabs of app open (either with incognito or with different browsers)
* in one log in as user with org, in the other stay on login page
* refresh the user with org table and try creating user registration, should see integer: "" error

How does this not work ?

When second tab is refreshed, postgraphile set jwt.claim.orgId = some number from JWT. This is not 'deleted' (set to null) for next postgres query but is set to ''. Now the next postgres query from postgraphile as nonRegistered user with no org still has jwt.claim.orgId = '', and this statement would fail in permission policies: `COALESCE(current_setting('jwt.claims.orgId', true),'0')::integer` because of the casting

Fix, make sure to also use nullif to handle empty string. i.e. the above statement becomes:
`COALESCE(nullif(current_setting('jwt.claims.orgId', true),''),'0')::integer` 
