### PR TITLE
Refactor: throw ApiError + central Fastify error handler

### DIFF
--- a/src/ApiError.ts
+++ b/src/ApiError.ts
@@ -1,11 +1,16 @@
-import { FastifyReply } from 'fastify'
+import { FastifyError, FastifyReply, FastifyRequest } from 'fastify'
 
 /**
- * A standardised Error object to return from the API whenever something is
- * incorrect. We should eventually move to using this for all API routes.
+ * A standardised Error object to throw from anywhere in the API request
+ * lifecycle when something is incorrect. Pair it with `apiErrorHandler`
+ * (registered via `fastify.setErrorHandler`) to translate into a response.
  *
- * Currently only implemented for:
- * - Template Import/Export
+ * Throw from route handlers, operations, or utilities:
+ *
+ *   throw new ApiError('Invalid template id', 400)
+ *
+ * Fastify auto-catches throws from async handlers and routes them through
+ * the error handler below.
  */
 
 export class ApiError extends Error {
@@ -15,44 +20,25 @@ export class ApiError extends Error {
     super(message)
     this.status = status
     if (name) this.name = name
-    console.log(`API Error: ${message}`)
   }
 }
 
-const logError = (message: string) => console.log('ERROR: ' + message)
-
-/**
- * Sends an error response on `reply` and returns the reply object. The `return`
- * inside this function only exits *this* function — it does NOT stop the
- * calling route handler. So in a route, prefer:
- *
- *   return returnApiError(...)            // or: returnApiError(...); return
- *
- * whenever there is any code (or a try/catch) after the call that could reach
- * another `reply.send()`. Fastify silently drops the second send and logs
- * "Reply already sent", but the intervening code still runs (wasted DB work,
- * misleading error logs).
- *
- * It's only safe to call `returnApiError(...)` without an explicit return when
- * nothing else in the handler can reach another send — e.g. the last line of
- * a `catch` block at the end of the function.
- */
-export const returnApiError = (err: unknown, reply: FastifyReply, statusCode?: number) => {
+export const apiErrorHandler = (
+  err: FastifyError,
+  _request: FastifyRequest,
+  reply: FastifyReply
+) => {
   if (err instanceof ApiError) {
-    reply.statusCode = err.status
-    logError(err.message)
-    return reply.send({ message: err.message })
+    console.log(`API Error (${err.status}): ${err.message}`)
+    return reply.status(err.status).send({ message: err.message })
   }
 
-  reply.statusCode = statusCode ?? 500
-
-  if (err instanceof Error) {
-    logError(err.message)
-    return reply.send({ message: err.message })
+  // Fastify's own 4xx (schema validation, body limits, 404, etc.) carry statusCode
+  if (err.statusCode && err.statusCode < 500) {
+    return reply.status(err.statusCode).send({ message: err.message })
   }
 
-  if (typeof err === 'string') {
-    logError(err)
-    return reply.send({ message: err })
-  }
+  // Anything else is unexpected — log loudly, mask details from the client
+  console.error('Unhandled server error:', err)
+  return reply.status(500).send({ message: 'Internal server error' })
 }

--- a/src/ApiError.ts
+++ b/src/ApiError.ts
@@ -33,7 +33,7 @@ export const apiErrorHandler = (
     return reply.status(err.status).send({ message: err.message })
   }
 
-  // Fastify's own 4xx (schema validation, body limits, 404, etc.) carry statusCode
+  // Fastify's own 4xx (schema validation, body limits, etc.) carry statusCode
   if (err.statusCode && err.statusCode < 500) {
     return reply.status(err.statusCode).send({ message: err.message })
   }

--- a/src/components/fig-tree-evaluator/routes.ts
+++ b/src/components/fig-tree-evaluator/routes.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from 'fastify'
 import DBConnect from '../database/databaseConnect'
-import { returnApiError } from '../../ApiError'
+import { ApiError } from '../../ApiError'
 import { getPermissionNamesFromJWT, getPublicTokenData } from '../permissions/loginHelpers'
 
 /** Routes for providing and updating FigTree fragments */
@@ -10,30 +10,29 @@ export const routeGetFragments = async (
   request: FastifyRequest<{ Querystring: { frontEnd?: 'true'; backEnd?: 'true' } }>,
   reply: FastifyReply
 ) => {
-  try {
-    const tokenData = await getPublicTokenData(request)
-    const { permissionNames } = await getPermissionNamesFromJWT(tokenData)
+  const tokenData = await getPublicTokenData(request)
+  const { permissionNames } = await getPermissionNamesFromJWT(tokenData)
 
-    const { frontEnd, backEnd } = request.query
+  const { frontEnd, backEnd } = request.query
 
-    if (!frontEnd && !backEnd)
-      return returnApiError('Either front-end or back-end must be specified', reply, 400)
+  if (!frontEnd && !backEnd)
+    throw new ApiError('Either front-end or back-end must be specified', 400)
 
-    const getFrontEnd = request.query.frontEnd === 'true'
-    const getBackEnd = request.query.backEnd === 'true' && tokenData.isAdmin === true
-    const getBoth = getFrontEnd && getBackEnd
+  const getFrontEnd = request.query.frontEnd === 'true'
+  const getBackEnd = request.query.backEnd === 'true' && tokenData.isAdmin === true
+  const getBoth = getFrontEnd && getBackEnd
 
-    if (!getFrontEnd && !getBackEnd)
-      return returnApiError('Must have Admin permissions to access back-end Fragments', reply, 403)
+  if (!getFrontEnd && !getBackEnd)
+    throw new ApiError('Must have Admin permissions to access back-end Fragments', 403)
 
-    const sqlClause = getBoth
-      ? 'AND (front_end = TRUE OR back_end = TRUE)'
-      : getBackEnd
-      ? 'AND back_end = TRUE'
-      : 'AND front_end = TRUE'
+  const sqlClause = getBoth
+    ? 'AND (front_end = TRUE OR back_end = TRUE)'
+    : getBackEnd
+    ? 'AND back_end = TRUE'
+    : 'AND front_end = TRUE'
 
-    const sqlQuery = `
-      SELECT id, name, 
+  const sqlQuery = `
+      SELECT id, name,
         expression, metadata
       FROM evaluator_fragment
       WHERE (
@@ -43,23 +42,20 @@ export const routeGetFragments = async (
            )
        ${sqlClause};`
 
-    const queryResult = (
-      await DBConnect.query({
-        text: sqlQuery,
-        values: [permissionNames],
-      })
-    ).rows
+  const queryResult = (
+    await DBConnect.query({
+      text: sqlQuery,
+      values: [permissionNames],
+    })
+  ).rows
 
-    const fragments = queryResult.reduce(
-      (frags, { name, expression, metadata }) => ({
-        ...frags,
-        [name]: { ...expression, metadata: metadata ?? undefined },
-      }),
-      {}
-    )
+  const fragments = queryResult.reduce(
+    (frags, { name, expression, metadata }) => ({
+      ...frags,
+      [name]: { ...expression, metadata: metadata ?? undefined },
+    }),
+    {}
+  )
 
-    return reply.send(fragments)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  return reply.send(fragments)
 }

--- a/src/components/template-import-export/routes.ts
+++ b/src/components/template-import-export/routes.ts
@@ -2,7 +2,7 @@ import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify'
 import fsx from 'fs-extra'
 import { pipeline } from 'stream'
 import { promisify } from 'util'
-import { returnApiError } from '../../ApiError'
+import { ApiError } from '../../ApiError'
 import {
   exportTemplate,
   duplicateTemplate,
@@ -48,17 +48,11 @@ const routeCommitTemplate = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
-  const comment = request.body?.comment ?? null
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
-  try {
-    const result = await commitTemplate(templateId, comment)
-    return reply.send(result)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const comment = request.body?.comment ?? null
+  const result = await commitTemplate(templateId, comment)
+  return reply.send(result)
 }
 
 const routeTemplateCheck = async (
@@ -66,16 +60,10 @@ const routeTemplateCheck = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
-  try {
-    const result = await checkTemplate(templateId)
-    return reply.send(result)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const result = await checkTemplate(templateId)
+  return reply.send(result)
 }
 
 const routeTemplatePrepareExport = async (
@@ -83,21 +71,13 @@ const routeTemplatePrepareExport = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
-  try {
-    const filename = await exportTemplate(templateId)
-    const { url } = await stageFileForDownload(
-      path.join(FILES_FOLDER, filename),
-      filename,
-      { consumeSource: true }
-    )
-    return reply.send({ url, filename })
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const filename = await exportTemplate(templateId)
+  const { url } = await stageFileForDownload(path.join(FILES_FOLDER, filename), filename, {
+    consumeSource: true,
+  })
+  return reply.send({ url, filename })
 }
 
 const routeDuplicateTemplateNew = async (
@@ -105,21 +85,13 @@ const routeDuplicateTemplateNew = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
   const code = request.body?.code
-  if (!code) {
-    returnApiError('New template code missing', reply, 400)
-  }
+  if (!code) throw new ApiError('New template code missing', 400)
 
-  try {
-    const result = await duplicateTemplate(templateId, code)
-    return reply.send(result)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const result = await duplicateTemplate(templateId, code)
+  return reply.send(result)
 }
 
 const routeDuplicateTemplateVersion = async (
@@ -127,16 +99,10 @@ const routeDuplicateTemplateVersion = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
-  try {
-    const result = await duplicateTemplate(templateId)
-    return reply.send(result)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const result = await duplicateTemplate(templateId)
+  return reply.send(result)
 }
 
 const routeImportTemplateUpload = async (request: FastifyRequest, reply: FastifyReply) => {
@@ -145,15 +111,12 @@ const routeImportTemplateUpload = async (request: FastifyRequest, reply: Fastify
     // @ts-ignore
     upload = await request.file()
   } catch (err) {
-    returnApiError('No file attached', reply, 400)
+    throw new ApiError('No file attached', 400)
   }
 
-  if (!upload) {
-    returnApiError('No file attached', reply, 400)
-    return
-  }
+  if (!upload) throw new ApiError('No file attached', 400)
 
-  if (upload?.mimetype !== 'application/zip') returnApiError('File is not a ZIP file', reply, 400)
+  if (upload.mimetype !== 'application/zip') throw new ApiError('File is not a ZIP file', 400)
 
   const tempZipLocation = path.join(FILES_TEMP_FOLDER, 'templateUpload.zip')
   await fsx.ensureDir(FILES_TEMP_FOLDER)
@@ -169,7 +132,7 @@ const routeImportTemplateUpload = async (request: FastifyRequest, reply: Fastify
     await zip.close()
     await fsx.remove(tempZipLocation)
   } catch (err) {
-    returnApiError(`Problem unzipping uploaded file: ${(err as Error).message}`, reply, 400)
+    throw new ApiError(`Problem unzipping uploaded file: ${(err as Error).message}`, 400)
   }
 
   const modifiedEntities = await importTemplateUpload(folderName)
@@ -181,11 +144,7 @@ const routeImportTemplateUpload = async (request: FastifyRequest, reply: Fastify
   // Cleanup temp upload if not installed within next 10 mins
   config.scheduledJobs?.manuallySchedule('fileCleanup', 10)
 
-  try {
-    return reply.send({ uid: folderName, modifiedEntities, ready })
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  return reply.send({ uid: folderName, modifiedEntities, ready })
 }
 
 const routeImportGetDiff = async (
@@ -196,18 +155,11 @@ const routeImportGetDiff = async (
   reply: FastifyReply
 ) => {
   const uid = request.params.uid
-  if (!uid) {
-    returnApiError('No UID specified for imported template', reply, 400)
-  }
+  if (!uid) throw new ApiError('No UID specified for imported template', 400)
 
   const { type, value } = request.query
-
-  try {
-    const result = await getSingleEntityDiff(uid, type, value)
-    return reply.send(result)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const result = await getSingleEntityDiff(uid, type, value)
+  return reply.send(result)
 }
 
 const routeImportTemplateInstall = async (
@@ -218,9 +170,7 @@ const routeImportTemplateInstall = async (
   reply: FastifyReply
 ) => {
   const uid = request.params.uid
-  if (!uid) {
-    returnApiError('No UID specified for template install', reply, 400)
-  }
+  if (!uid) throw new ApiError('No UID specified for template install', 400)
 
   const preserveExistingEntities = request.body ?? {}
 
@@ -230,12 +180,8 @@ const routeImportTemplateInstall = async (
       .map(([key, value]) => [key, key === 'category' ? value : new Set(value)])
   )
 
-  try {
-    const result = await importTemplateInstall(uid, preserveExistingEntitySets)
-    return reply.send(result)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const result = await importTemplateInstall(uid, preserveExistingEntitySets)
+  return reply.send(result)
 }
 
 const routeGetDataViewDetails = async (
@@ -243,16 +189,10 @@ const routeGetDataViewDetails = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
-  try {
-    const dataViews = await getDataViewDetails(templateId)
-    return reply.send(dataViews)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const dataViews = await getDataViewDetails(templateId)
+  return reply.send(dataViews)
 }
 
 const routeGetFragmentDetails = async (
@@ -260,16 +200,10 @@ const routeGetFragmentDetails = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
-  try {
-    const fragments = await getFragmentDetails(templateId)
-    return reply.send(fragments)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const fragments = await getFragmentDetails(templateId)
+  return reply.send(fragments)
 }
 
 const routeGetLinkedFiles = async (
@@ -277,16 +211,10 @@ const routeGetLinkedFiles = async (
   reply: FastifyReply
 ) => {
   const templateId = Number(request.params.id)
-  if (!templateId || isNaN(templateId)) {
-    returnApiError('Invalid template id', reply, 400)
-  }
+  if (!templateId) throw new ApiError('Invalid template id', 400)
 
-  try {
-    const files = await getLinkedFiles(templateId)
-    return reply.send(files)
-  } catch (err) {
-    returnApiError(err, reply)
-  }
+  const files = await getLinkedFiles(templateId)
+  return reply.send(files)
 }
 
 const getRandomTemplateFolderName = customAlphabet('abcdefghijklmnopqrstuvwxyz1234567890', 24)

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,6 +67,7 @@ import { convertHandler, pgMiddleware } from './postgraphile'
 import { routeGetFragments } from './components/fig-tree-evaluator/routes'
 import { loadStartupSnapshot } from './components/snapshots/loadStartupSnapshot'
 import databaseConnect from './components/database/databaseConnect'
+import { apiErrorHandler } from './ApiError'
 
 require('dotenv').config()
 
@@ -99,6 +100,8 @@ const startServer = async () => {
   config.latestSnapshot = await databaseConnect.getSystemInfo('snapshot')
 
   const server = fastify()
+
+  server.setErrorHandler(apiErrorHandler)
 
   // For serving static files from "Files" folder
   server.register(fastifyStatic, {


### PR DESCRIPTION
Closes #1145.

## Summary

- Replaced `returnApiError(err, reply, statusCode?)` (which couldn't actually stop the calling route handler) with a `throw new ApiError(...)` pattern routed through a single `server.setErrorHandler(...)` registered in `src/server.ts`. Throwing actually stops execution, so the fall-through bug class — wasted DB queries on `NaN` ids, "Reply already sent" warnings, misleading post-validation error logs — is fixed by construction.
- Slimmed `ApiError`: removed the `console.log` side effect from the constructor (logging now happens once, in the handler) and added `apiErrorHandler` in the same file (tightly coupled, file stays small).
- Converted 26 call sites across `template-import-export/routes.ts` (23) and `fig-tree-evaluator/routes.ts` (3). 11 pure `try { ... } catch { returnApiError(err, reply) }` wrappers deleted — Fastify auto-catches throws from async handlers. The two catches in `routeImportTemplateUpload` that translate non-`ApiError` errors into a friendly 400 (multipart parsing, zip extraction) are preserved as `throw new ApiError(...)`; without them those would surface as masked 500s.
- 5xx responses are now masked as `{ message: 'Internal server error' }` to avoid leaking DB/stack details to clients; the real error + stack is logged server-side. 4xx responses keep their real message (deliberate user-facing text). Inventory confirmed no tests assert on 5xx body text and the web-app handles a generic 5xx message gracefully.
- The 28 `throw new ApiError(...)` sites in operations/utilities files are unchanged — they were always correct; this refactor just gives them a proper landing place at the route boundary.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `grep -rn returnApiError src/` returns nothing
- [x] 4xx validation guards return `{"message":"..."}` and emit exactly one `API Error (400): ...` log line per request — no follow-on errors, no "Reply already sent"
- [x] 4xx throws from operations files (e.g. "Template N does not exist", "Template N has already been committed") still propagate to client correctly
- [x] 5xx masked: synthetic `throw new Error('... secret_password=hunter2')` in `commitTemplate` returns `{"message":"Internal server error"}` to client, full error + stack in server logs only
- [x] File-upload edge cases: non-zip mimetype returns `{"message":"File is not a ZIP file"}` with no subsequent pump/zip errors in logs; corrupt zip returns `{"message":"Problem unzipping uploaded file: <real error>"}` (4xx, not masked)

## Notes

- Fastify's default not-found handler is unchanged (still emits `{message, error, statusCode}` for unknown routes). If we want unknown-route 404s to also use our `{message}`-only shape, that would need a separate `server.setNotFoundHandler(...)` — not in scope here.